### PR TITLE
Add widget configuration to app.json

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -19,6 +19,24 @@
   "category": [
     "appliances"
   ],
+  "widgets": {
+    "car-status": {
+      "name": {
+        "en": "Car Status",
+        "nl": "Auto Status",
+        "de": "Fahrzeugstatus"
+      },
+      "height": 160,
+      "api": {
+        "getStatus": {
+          "method": "GET",
+          "path": "/"
+        }
+      },
+      "id": "car-status",
+      "settings": []
+    }
+  },
   "tags": {
     "en": [
       "mercedes",

--- a/app.json
+++ b/app.json
@@ -20,6 +20,24 @@
   "category": [
     "appliances"
   ],
+  "widgets": {
+    "car-status": {
+      "name": {
+        "en": "Car Status",
+        "nl": "Auto Status",
+        "de": "Fahrzeugstatus"
+      },
+      "height": 160,
+      "api": {
+        "getStatus": {
+          "method": "GET",
+          "path": "/"
+        }
+      },
+      "id": "car-status",
+      "settings": []
+    }
+  },
   "tags": {
     "en": [
       "mercedes",


### PR DESCRIPTION
## Summary
- Add car-status widget configuration block to app.json and .homeycompose/app.json

## Test plan
- [ ] Verify widget appears in Homey dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)