### PR TITLE
Remove homey:manager:api permission, fix widget device lookup

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -62,5 +62,8 @@
   },
   "1.1.13": {
     "en": " Fix widget, tier values and deprecated custom trigger for vehicle_locked/vehicle_unlocked"
+  },
+  "1.1.14": {
+    "en": "Remove the need for the homey:manager:api permission, previous used in the widget"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -67,10 +67,7 @@
       "ev"
     ]
   },
-  "permissions": [
-    "homey:manager:api"
-  ],
-  "images": {
+"images": {
     "small": "/assets/images/small.png",
     "large": "/assets/images/large.png",
     "xlarge": "/assets/images/xlarge.png"

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.mercedes.mbapi",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [
@@ -67,7 +67,7 @@
       "ev"
     ]
   },
-"images": {
+  "images": {
     "small": "/assets/images/small.png",
     "large": "/assets/images/large.png",
     "xlarge": "/assets/images/xlarge.png"

--- a/app.js
+++ b/app.js
@@ -1,34 +1,11 @@
 'use strict';
 
 const Homey = require('homey');
-const axios = require('axios');
 
 class MercedesMeApp extends Homey.App {
 
   async onInit() {
     this.log('Mercedes-Benz app has been initialized');
-    this._uuidToDataId = {};
-    await this._buildUuidMap();
-  }
-
-  async _buildUuidMap() {
-    try {
-      const token = await this.homey.api.getOwnerApiToken();
-      const baseUrl = await this.homey.api.getLocalUrl();
-      const response = await axios.get(`${baseUrl}/api/manager/devices/device/`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const devices = response.data;
-      this._uuidToDataId = {};
-      for (const device of Object.values(devices)) {
-        if (device.driverId?.includes('com.mercedes.mbapi')) {
-          this._uuidToDataId[device.id] = device.data.id;
-          this.log(`[uuid-map] ${device.id} → ${device.data.id} (${device.name})`);
-        }
-      }
-    } catch (e) {
-      this.log(`[uuid-map] failed: ${e.message}`);
-    }
   }
 
   _getDevices() {
@@ -46,16 +23,8 @@ class MercedesMeApp extends Homey.App {
   async getDeviceStatus(deviceId) {
     if (!deviceId) return { error: 'not_configured' };
 
-    // Resolve Homey UUID → pairing data ID (VIN / dummy ID)
-    let dataId = this._uuidToDataId[deviceId] || deviceId;
-    let device = this._getDevices().find(d => d.getData().id === dataId);
-
-    // If not found, the map may be stale (device added after app init) — rebuild and retry
-    if (!device) {
-      await this._buildUuidMap();
-      dataId = this._uuidToDataId[deviceId] || deviceId;
-      device = this._getDevices().find(d => d.getData().id === dataId);
-    }
+    // Match by Homey UUID (widget device picker) or VIN/data.id (backward compat)
+    let device = this._getDevices().find(d => d.id === deviceId || d.getData().id === deviceId);
 
     if (!device) return { error: 'not_configured' };
 

--- a/app.js
+++ b/app.js
@@ -24,7 +24,7 @@ class MercedesMeApp extends Homey.App {
     if (!deviceId) return { error: 'not_configured' };
 
     // Match by Homey UUID (widget device picker) or VIN/data.id (backward compat)
-    let device = this._getDevices().find(d => d.id === deviceId || d.getData().id === deviceId);
+    let device = this._getDevices().find(d => d.__id === deviceId || d.getData().id === deviceId);
 
     if (!device) return { error: 'not_configured' };
 

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.mercedes.mbapi",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -80,9 +80,6 @@
       "ev"
     ]
   },
-  "permissions": [
-    "homey:manager:api"
-  ],
   "images": {
     "small": "/assets/images/small.png",
     "large": "/assets/images/large.png",


### PR DESCRIPTION
## Summary
- Removed `homey:manager:api` permission by eliminating the UUID-to-data-ID mapping that required internal API calls
- Simplified widget device lookup to match by `__id` (Homey UUID) or `getData().id` (VIN)
- Removed unused `axios` dependency from app.js
- Version bump to 1.1.14

## Test plan
- [x] Widget correctly displays car status after selecting a device
- [x] App deploys and receives WebSocket updates normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)