### PR TITLE
Fix auth failure by updating Mercedes SDK headers (closes #28)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -65,5 +65,8 @@
   },
   "1.1.14": {
     "en": "Remove the need for the homey:manager:api permission, previous used in the widget"
+  },
+  "1.1.16": {
+    "en": "Fix auth issue due to outdated ris-sdk-version header"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.mercedes.mbapi",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.mercedes.mbapi",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.mercedes.mbapi",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.mercedes.mbapi",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [

--- a/lib/api.js
+++ b/lib/api.js
@@ -71,10 +71,10 @@ class MercedesAPI {
       'X-SessionId': this.sessionId,
       'X-TrackingId': crypto.randomUUID().toUpperCase(),
       'X-ApplicationName': 'mycar-store-ece',
-      'ris-application-version': '1.63.0 (3044)',
+      'ris-application-version': '1.65.1 (3174)',
       'ris-os-name': 'ios',
       'ris-os-version': '26.3',
-      'ris-sdk-version': '3.26.2',
+      'ris-sdk-version': '4.4.2',
       'X-Locale': 'en-GB',
       'Content-Type': 'application/json; charset=UTF-8',
       'Accept': 'application/json'

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -576,10 +576,10 @@ class MercedesOAuth {
       'X-SessionId': crypto.randomUUID().toUpperCase(),
       'X-TrackingId': crypto.randomUUID().toUpperCase(),
       'X-ApplicationName': 'mycar-store-ece',
-      'ris-application-version': '1.63.0 (3044)',
+      'ris-application-version': '1.65.1 (3174)',
       'ris-os-name': 'ios',
       'ris-os-version': '26.3',
-      'ris-sdk-version': '3.26.2',
+      'ris-sdk-version': '4.4.2',
       'X-Locale': 'de-DE',
       'User-Agent': 'Mercedes-Benz/3044 CFNetwork/3860.400.22 Darwin/25.3.0',
       'Content-Type': 'application/json; charset=UTF-8'

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -106,11 +106,11 @@ class MercedesWebSocket {
       'X-TrackingId': crypto.randomUUID().toUpperCase(),
       'ris-os-name': 'ios',
       'ris-os-version': '26.3',
-      'ris-sdk-version': '3.26.2',
+      'ris-sdk-version': '4.4.2',
       'X-Locale': 'en-GB',
       'User-Agent': 'Mercedes-Benz/3044 CFNetwork/3860.400.22 Darwin/25.3.0',
       'X-ApplicationName': 'mycar-store-ece',
-      'ris-application-version': '1.63.0 (3044)'
+      'ris-application-version': '1.65.1 (3174)'
     };
 
     return headers;


### PR DESCRIPTION
## Summary
- Mercedes servers started rejecting our old SDK headers with HTTP 418, causing the app to stop working after install for many users.
- Bumped `ris-sdk-version` `3.26.2` → `4.4.2` and `ris-application-version` `1.63.0 (3044)` → `1.65.1 (3174)` in `lib/api.js`, `lib/oauth.js`, and `lib/websocket.js` to match the current mbapi2020 reference.
- Bumped app version to `1.1.16` with changelog entry.

Fixes #28

## Test plan
- [ ] Fresh install authenticates successfully
- [ ] Vehicle data updates via REST API
- [ ] WebSocket stays connected and delivers live updates
- [ ] Commands (lock/unlock, charging) succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)