### PR TITLE
Fix engine triggers on EVs and restore repair flow (closes #27)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -68,5 +68,8 @@
   },
   "1.1.16": {
     "en": "Fix auth issue due to outdated ris-sdk-version header"
+  },
+  "1.1.17": {
+    "en": "Fix engine started/stopped triggers on electric vehicles, restore device repair flow, and migrate engine/ignition/climate capabilities for flow tag support"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.mercedes.mbapi",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [

--- a/.homeycompose/capabilities/climate_active.json
+++ b/.homeycompose/capabilities/climate_active.json
@@ -1,0 +1,23 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "Climate active",
+    "nl": "Klimaat actief",
+    "de": "Klimaanlage aktiv"
+  },
+  "getable": true,
+  "setable": true,
+  "uiComponent": "toggle",
+  "icon": "/assets/icons/precond.svg",
+  "insights": true,
+  "insightsTitleTrue": {
+    "en": "Climate turned on",
+    "nl": "Klimaat aan",
+    "de": "Klimaanlage an"
+  },
+  "insightsTitleFalse": {
+    "en": "Climate turned off",
+    "nl": "Klimaat uit",
+    "de": "Klimaanlage aus"
+  }
+}

--- a/.homeycompose/capabilities/engine_running.json
+++ b/.homeycompose/capabilities/engine_running.json
@@ -1,0 +1,23 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "Engine running",
+    "nl": "Motor draait",
+    "de": "Motor läuft"
+  },
+  "getable": true,
+  "setable": false,
+  "uiComponent": "sensor",
+  "icon": "/assets/icons/remote_start.svg",
+  "insights": true,
+  "insightsTitleTrue": {
+    "en": "Engine started",
+    "nl": "Motor gestart",
+    "de": "Motor gestartet"
+  },
+  "insightsTitleFalse": {
+    "en": "Engine stopped",
+    "nl": "Motor gestopt",
+    "de": "Motor gestoppt"
+  }
+}

--- a/.homeycompose/capabilities/ignition_on.json
+++ b/.homeycompose/capabilities/ignition_on.json
@@ -1,0 +1,22 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "Ignition on",
+    "nl": "Ontsteking aan",
+    "de": "Zündung an"
+  },
+  "getable": true,
+  "setable": false,
+  "uiComponent": "sensor",
+  "insights": true,
+  "insightsTitleTrue": {
+    "en": "Ignition turned on",
+    "nl": "Ontsteking aan",
+    "de": "Zündung eingeschaltet"
+  },
+  "insightsTitleFalse": {
+    "en": "Ignition turned off",
+    "nl": "Ontsteking uit",
+    "de": "Zündung ausgeschaltet"
+  }
+}

--- a/.homeycompose/drivers/mercedes-vehicle/driver.compose.json
+++ b/.homeycompose/drivers/mercedes-vehicle/driver.compose.json
@@ -30,7 +30,7 @@
     "measure_range_liquid",
     "measure_fuel",
     "measure_adblue_level",
-    "onoff.ignition",
+    "ignition_on",
     "measure_oil_level",
     "text_charging_status",
     "text_charge_program",
@@ -67,8 +67,8 @@
     "onoff_auxheat",
     "onoff_remote_start",
     "theft_system_armed",
-    "onoff.engine",
-    "onoff.climate"
+    "engine_running",
+    "climate_active"
   ],
   "capabilitiesOptions": {
     "tire_pressure_bar.tire_fl": {
@@ -98,27 +98,6 @@
         "nl": "Bandenspanning, Rechts Achter",
         "de": "Reifendruck, Hinten Rechts"
       }
-    },
-    "onoff.ignition": {
-      "title": {
-        "en": "Ignition On",
-        "nl": "Ontsteking aan",
-        "de": "Zündung an"
-      }
-    },
-    "onoff.engine": {
-      "title": {
-        "en": "Engine Running",
-        "nl": "Motor draait",
-        "de": "Motor läuft"
-      }
-    },
-    "onoff.climate": {
-      "title": {
-        "en": "Climate Active",
-        "nl": "Klimaat actief",
-        "de": "Klimaanlage aktiv"
-      }
     }
   },
   "pair": [
@@ -138,4 +117,10 @@
       "template": "add_devices"
     }
   ],
+  "repair": [
+    {
+      "id": "login_credentials",
+      "template": "login_credentials"
+    }
+  ]
 }

--- a/app.js
+++ b/app.js
@@ -54,8 +54,8 @@ class MercedesMeApp extends Homey.App {
       },
       sunroof: getValue('window_sunroof'),
       chargingStatus: getValue('text_charging_status'),
-      engineRunning: getValue('onoff.engine'),
-      climateOn: getValue('onoff.climate'),
+      engineRunning: getValue('engine_running'),
+      climateOn: getValue('climate_active'),
       model: device.getName(),
       pollingInterval: (device.getSetting('polling_interval') || 180) * 1000,
     };

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.mercedes.mbapi",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [
@@ -1604,7 +1604,7 @@
         "measure_range_liquid",
         "measure_fuel",
         "measure_adblue_level",
-        "onoff.ignition",
+        "ignition_on",
         "measure_oil_level",
         "text_charging_status",
         "text_charge_program",
@@ -1641,8 +1641,8 @@
         "onoff_auxheat",
         "onoff_remote_start",
         "theft_system_armed",
-        "onoff.engine",
-        "onoff.climate"
+        "engine_running",
+        "climate_active"
       ],
       "pair": [
         {
@@ -1659,6 +1659,12 @@
         {
           "id": "add_devices",
           "template": "add_devices"
+        }
+      ],
+      "repair": [
+        {
+          "id": "login_credentials",
+          "template": "login_credentials"
         }
       ],
       "energy": {
@@ -1773,6 +1779,29 @@
       "decimals": 1,
       "min": 0,
       "max": 250
+    },
+    "climate_active": {
+      "type": "boolean",
+      "title": {
+        "en": "Climate active",
+        "nl": "Klimaat actief",
+        "de": "Klimaanlage aktiv"
+      },
+      "getable": true,
+      "setable": true,
+      "uiComponent": "toggle",
+      "icon": "/assets/icons/precond.svg",
+      "insights": true,
+      "insightsTitleTrue": {
+        "en": "Climate turned on",
+        "nl": "Klimaat aan",
+        "de": "Klimaanlage an"
+      },
+      "insightsTitleFalse": {
+        "en": "Climate turned off",
+        "nl": "Klimaat uit",
+        "de": "Klimaanlage aus"
+      }
     },
     "distance_electrical": {
       "type": "number",
@@ -1944,6 +1973,51 @@
       "setable": false,
       "uiComponent": "sensor",
       "icon": "/assets/icons/ecoscore.svg"
+    },
+    "engine_running": {
+      "type": "boolean",
+      "title": {
+        "en": "Engine running",
+        "nl": "Motor draait",
+        "de": "Motor läuft"
+      },
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor",
+      "icon": "/assets/icons/remote_start.svg",
+      "insights": true,
+      "insightsTitleTrue": {
+        "en": "Engine started",
+        "nl": "Motor gestart",
+        "de": "Motor gestartet"
+      },
+      "insightsTitleFalse": {
+        "en": "Engine stopped",
+        "nl": "Motor gestopt",
+        "de": "Motor gestoppt"
+      }
+    },
+    "ignition_on": {
+      "type": "boolean",
+      "title": {
+        "en": "Ignition on",
+        "nl": "Ontsteking aan",
+        "de": "Zündung an"
+      },
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor",
+      "insights": true,
+      "insightsTitleTrue": {
+        "en": "Ignition turned on",
+        "nl": "Ontsteking aan",
+        "de": "Zündung eingeschaltet"
+      },
+      "insightsTitleFalse": {
+        "en": "Ignition turned off",
+        "nl": "Ontsteking uit",
+        "de": "Zündung ausgeschaltet"
+      }
     },
     "measure_adblue_level": {
       "type": "number",

--- a/drivers/mercedes-vehicle/device.js
+++ b/drivers/mercedes-vehicle/device.js
@@ -50,8 +50,8 @@ class MercedesVehicleDevice extends Homey.Device {
 
       // Register capability listeners
       this.registerCapabilityListener('locked', this.onCapabilityLocked.bind(this));
-      this.registerCapabilityListener('onoff.engine', this.onCapabilityEngine.bind(this));
-      this.registerCapabilityListener('onoff.climate', this.onCapabilityClimate.bind(this));
+      this.registerCapabilityListener('engine_running', this.onCapabilityEngine.bind(this));
+      this.registerCapabilityListener('climate_active', this.onCapabilityClimate.bind(this));
       this.registerCapabilityListener('onoff_charging', this.onCapabilityCharging.bind(this));
 
       // Add average_speed capability if it doesn't exist (for devices paired before this was added)
@@ -292,22 +292,40 @@ class MercedesVehicleDevice extends Homey.Device {
         await this.addCapability('onoff_remote_start');
       }
 
-      // Add onoff.ignition capability
-      if (!this.hasCapability('onoff.ignition')) {
-        this.log('[INIT] Adding missing onoff.ignition capability');
-        await this.addCapability('onoff.ignition');
+      // Migrate to ignition_on (top-level capability so flow tags pick up the title)
+      for (const old of ['onoff.ignition', 'onoff_ignition']) {
+        if (this.hasCapability(old)) {
+          this.log(`[INIT] Removing deprecated ${old} capability`);
+          await this.removeCapability(old);
+        }
+      }
+      if (!this.hasCapability('ignition_on')) {
+        this.log('[INIT] Adding ignition_on capability');
+        await this.addCapability('ignition_on');
       }
 
-      // Add onoff.engine capability
-      if (!this.hasCapability('onoff.engine')) {
-        this.log('[INIT] Adding missing onoff.engine capability');
-        await this.addCapability('onoff.engine');
+      // Migrate to engine_running
+      for (const old of ['onoff.engine', 'onoff_engine']) {
+        if (this.hasCapability(old)) {
+          this.log(`[INIT] Removing deprecated ${old} capability`);
+          await this.removeCapability(old);
+        }
+      }
+      if (!this.hasCapability('engine_running')) {
+        this.log('[INIT] Adding engine_running capability');
+        await this.addCapability('engine_running');
       }
 
-      // Add onoff.climate capability
-      if (!this.hasCapability('onoff.climate')) {
-        this.log('[INIT] Adding missing onoff.climate capability');
-        await this.addCapability('onoff.climate');
+      // Migrate to climate_active
+      for (const old of ['onoff.climate', 'onoff_climate']) {
+        if (this.hasCapability(old)) {
+          this.log(`[INIT] Removing deprecated ${old} capability`);
+          await this.removeCapability(old);
+        }
+      }
+      if (!this.hasCapability('climate_active')) {
+        this.log('[INIT] Adding climate_active capability');
+        await this.addCapability('climate_active');
       }
 
       // Migrate theft system armed capability from alarm_theft_system to theft_system_armed
@@ -667,27 +685,51 @@ class MercedesVehicleDevice extends Homey.Device {
         }
       }
 
-      // Engine state - check both lowercase and camelCase variants
+      // Engine state — Mercedes sends `enginestate` for ICE cars; EVs don't
+      // include that key, so fall back to `ignitionstate` (4 = engine on / ready).
       const engineStateValue = data.enginestate ?? data.engineState;
+      const ignitionValue = data.ignitionstate;
+      let engineRunning = null;
+      let engineSource = null;
+
       if (engineStateValue !== undefined) {
-        const engineRunning = engineStateValue === true || engineStateValue === 'RUNNING';
-        const wasRunning = this.getCapabilityValue('onoff.engine');
+        engineSource = 'enginestate';
+        if (typeof engineStateValue === 'boolean') {
+          engineRunning = engineStateValue;
+        } else if (typeof engineStateValue === 'string') {
+          const s = engineStateValue.toUpperCase();
+          engineRunning = s === 'RUNNING' || s === 'ON' || s === '1' || s === 'TRUE';
+        } else {
+          engineRunning = Number(engineStateValue) === 1;
+        }
+      } else if (ignitionValue !== undefined) {
+        engineSource = 'ignitionstate';
+        engineRunning = Number(ignitionValue) === 4; // 4 = start (engine/EV ready to drive)
+      }
+
+      if (engineRunning !== null) {
+        const wasRunning = this.getCapabilityValue('engine_running');
+        this.log(`[UPDATE] Engine state from ${engineSource}=${engineSource === 'enginestate' ? engineStateValue : ignitionValue} -> running=${engineRunning}, was=${wasRunning}`);
 
         if (wasRunning !== engineRunning) {
-          await this.setCapabilityValue('onoff.engine', engineRunning);
+          await this.setCapabilityValue('engine_running', engineRunning);
 
-          // Trigger flow cards
-          if (engineRunning) {
-            await this.homey.flow.getDeviceTriggerCard('engine_started').trigger(this);
-          } else {
-            await this.homey.flow.getDeviceTriggerCard('engine_stopped').trigger(this);
+          // Skip triggers on initial read (capability was null/unset before)
+          if (wasRunning !== null && wasRunning !== undefined) {
+            if (engineRunning) {
+              this.log('[TRIGGER] Firing engine_started');
+              await this.homey.flow.getDeviceTriggerCard('engine_started').trigger(this);
+            } else {
+              this.log('[TRIGGER] Firing engine_stopped');
+              await this.homey.flow.getDeviceTriggerCard('engine_stopped').trigger(this);
+            }
           }
         }
       }
 
       // Climate control status
       if (data.precondActive !== undefined) {
-        await this.setCapabilityValue('onoff.climate', data.precondActive === true);
+        await this.setCapabilityValue('climate_active', data.precondActive === true);
       }
 
       // Tire pressures (already converted from kPa to bar in parser)
@@ -801,11 +843,12 @@ class MercedesVehicleDevice extends Homey.Device {
       }
 
 
-      // Ignition state (onoff.ignition)
+      // Ignition state
       if (data.ignitionstate !== undefined) {
-        const ignitionOn = data.ignitionstate === '1' || data.ignitionstate === '2' || data.ignitionstate === '4'; // 0: lock/off, 1: radio, 2: ignition, 4: start
+        const raw = Number(data.ignitionstate);
+        const ignitionOn = raw === 1 || raw === 2 || raw === 4; // 0: lock/off, 1: radio, 2: ignition, 4: start
         this.log(`[UPDATE] Setting ignition state to: ${ignitionOn} (raw: ${data.ignitionstate})`);
-        await this.setCapabilityValue('onoff.ignition', ignitionOn);
+        await this.setCapabilityValue('ignition_on', ignitionOn);
       }
 
       // Oil level (percent)
@@ -1314,14 +1357,14 @@ class MercedesVehicleDevice extends Homey.Device {
    * Start climate control
    */
   async startClimate() {
-    await this.setCapabilityValue('onoff.climate', true);
+    await this.setCapabilityValue('climate_active', true);
   }
 
   /**
    * Stop climate control
    */
   async stopClimate() {
-    await this.setCapabilityValue('onoff.climate', false);
+    await this.setCapabilityValue('climate_active', false);
   }
 
   /**
@@ -1341,14 +1384,14 @@ class MercedesVehicleDevice extends Homey.Device {
    * Start engine
    */
   async startEngine() {
-    await this.setCapabilityValue('onoff.engine', true);
+    await this.setCapabilityValue('engine_running', true);
   }
 
   /**
    * Stop engine
    */
   async stopEngine() {
-    await this.setCapabilityValue('onoff.engine', false);
+    await this.setCapabilityValue('engine_running', false);
   }
 
   /**
@@ -1435,7 +1478,7 @@ class MercedesVehicleDevice extends Homey.Device {
       this.log('[FLOW] Climate control started successfully');
 
       // Update capability immediately
-      await this.setCapabilityValue('onoff.climate', true);
+      await this.setCapabilityValue('climate_active', true);
 
       return true;
     } catch (error) {
@@ -1455,7 +1498,7 @@ class MercedesVehicleDevice extends Homey.Device {
       this.log('[FLOW] Climate control stopped successfully');
 
       // Update capability immediately
-      await this.setCapabilityValue('onoff.climate', false);
+      await this.setCapabilityValue('climate_active', false);
 
       return true;
     } catch (error) {
@@ -1496,7 +1539,7 @@ class MercedesVehicleDevice extends Homey.Device {
       this.log('[FLOW] Engine started successfully');
 
       // Update capability immediately
-      await this.setCapabilityValue('onoff.engine', true);
+      await this.setCapabilityValue('engine_running', true);
 
       return true;
     } catch (error) {
@@ -1515,7 +1558,7 @@ class MercedesVehicleDevice extends Homey.Device {
       this.log('[FLOW] Engine stopped successfully');
 
       // Update capability immediately
-      await this.setCapabilityValue('onoff.engine', false);
+      await this.setCapabilityValue('engine_running', false);
 
       return true;
     } catch (error) {
@@ -1643,7 +1686,7 @@ class MercedesVehicleDevice extends Homey.Device {
    * Flow condition: Is engine running?
    */
   async isEngineRunning() {
-    const running = this.getCapabilityValue('onoff.engine');
+    const running = this.getCapabilityValue('engine_running');
     this.log(`[FLOW] Is engine running condition checked: ${running}`);
     return running === true;
   }

--- a/drivers/mercedes-vehicle/driver.compose.json
+++ b/drivers/mercedes-vehicle/driver.compose.json
@@ -33,7 +33,7 @@
     "measure_range_liquid",
     "measure_fuel",
     "measure_adblue_level",
-    "onoff.ignition",
+    "ignition_on",
     "measure_oil_level",
     "text_charging_status",
     "text_charge_program",
@@ -70,8 +70,8 @@
     "onoff_auxheat",
     "onoff_remote_start",
     "theft_system_armed",
-    "onoff.engine",
-    "onoff.climate"
+    "engine_running",
+    "climate_active"
   ],
   "pair": [
     {
@@ -88,6 +88,12 @@
     {
       "id": "add_devices",
       "template": "add_devices"
+    }
+  ],
+  "repair": [
+    {
+      "id": "login_credentials",
+      "template": "login_credentials"
     }
   ],
   "energy": {

--- a/drivers/mercedes-vehicle/driver.js
+++ b/drivers/mercedes-vehicle/driver.js
@@ -415,8 +415,8 @@ class MercedesVehicleDriver extends Homey.Driver {
             'tire_pressure_bar.tire_fr',
             'tire_pressure_bar.tire_rl',
             'tire_pressure_bar.tire_rr',
-            'onoff.engine',
-            'onoff.climate'
+            'engine_running',
+            'climate_active'
           ],
           store: {
             username: credentials.username,
@@ -438,6 +438,98 @@ class MercedesVehicleDriver extends Homey.Driver {
         return deviceObj;
       });
     });
+  }
+
+  /**
+   * onRepair is called when a user starts the repair flow for a device.
+   * Re-authenticates credentials, refreshes the stored token, and purges
+   * obsolete onoff.* / onoff_* subcapabilities so flow tags render correctly.
+   */
+  async onRepair(session, device) {
+    this.log('Repair flow started for device:', device.getName());
+
+    session.setHandler('login', async (data) => {
+      this.log('Repair login attempt for:', data.username);
+
+      const region = device.getStoreValue('region') || 'Europe';
+      const existingDeviceGuid = device.getStoreValue('deviceGuid') || null;
+
+      try {
+        const oauth = new MercedesOAuth(this.homey, region, existingDeviceGuid);
+        await oauth.login(data.username, data.password);
+        this.log('Repair login successful');
+
+        await device.setStoreValue('username', data.username);
+        await device.setStoreValue('password', data.password);
+        await device.setStoreValue('token', oauth.token);
+        if (!existingDeviceGuid) {
+          await device.setStoreValue('deviceGuid', oauth.deviceGuid);
+        }
+
+        await this._migrateVehicleCapabilities(device);
+
+        if (device.pollInterval) {
+          clearInterval(device.pollInterval);
+          device.pollInterval = null;
+        }
+        if (device.api && typeof device.api.disconnectWebSocket === 'function') {
+          try {
+            await device.api.disconnectWebSocket();
+          } catch (wsError) {
+            this.error('WebSocket disconnect during repair failed (non-fatal):', wsError.message);
+          }
+        }
+
+        if (typeof device.onInit === 'function') {
+          try {
+            await device.onInit();
+          } catch (reinitError) {
+            this.error('Device re-init after repair failed (non-fatal):', reinitError.message);
+          }
+        }
+
+        await device.setAvailable().catch(() => {});
+
+        return true;
+      } catch (error) {
+        this.error('Repair login failed:', error.message);
+
+        if (error.message && (error.message.includes('418') || error.message.includes('status code 418'))) {
+          throw new Error('Too many requests. Please wait 15-30 minutes and try again.');
+        } else if (error.message && (error.message.includes('403') || error.message.includes('status code 403'))) {
+          throw new Error('Access denied. Please check your credentials.');
+        } else if (error.message && error.message.includes('2FA')) {
+          throw new Error('Two-factor authentication is not supported. Please disable 2FA.');
+        }
+        throw new Error(error.message || this.homey.__('pair.login_failed'));
+      }
+    });
+  }
+
+  /**
+   * Drop deprecated onoff.engine/ignition/climate subcapabilities and
+   * onoff_engine/ignition/climate intermediates, then ensure the new
+   * top-level capabilities exist.
+   */
+  async _migrateVehicleCapabilities(device) {
+    const migrations = [
+      { deprecated: ['onoff.ignition', 'onoff_ignition'], current: 'ignition_on' },
+      { deprecated: ['onoff.engine', 'onoff_engine'], current: 'engine_running' },
+      { deprecated: ['onoff.climate', 'onoff_climate'], current: 'climate_active' },
+    ];
+
+    for (const { deprecated, current } of migrations) {
+      for (const old of deprecated) {
+        if (device.hasCapability(old)) {
+          this.log(`[REPAIR] Removing deprecated capability ${old}`);
+          await device.removeCapability(old);
+        }
+      }
+      if (!device.hasCapability(current)) {
+        this.log(`[REPAIR] Adding capability ${current}`);
+        await device.addCapability(current);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixes `Engine was started` / `Engine was stopped` triggers (and the `Engine is running` condition card) on electric vehicles by falling back to `ignitionstate` when `enginestate` is absent — Mercedes never sends `enginestate` for EVs, so the previous check always evaluated to `false`.
- Restores the device Repair flow: the repair section was declared in `.homeycompose` but never reached the built manifest, so Homey had no view to render. Also tightened `onRepair` to preserve `deviceGuid`, clear polling/WebSocket before re-init, and set device available on success.
- Migrates deprecated `onoff.engine` / `onoff.ignition` / `onoff.climate` subcapabilities to new top-level `engine_running` / `ignition_on` / `climate_active` capabilities so their values are usable as flow tags.
- Bumps version to 1.1.17 and adds changelog entry.

Closes #27.

## Test plan
- [x] Validates at `publish` level (`homey app validate --level publish`).
- [x] Installed on Homey Pro, verified live: four ignition 0↔4 (and 4→2→4) transitions on an EV fired `engine_started` / `engine_stopped` correctly — no fire on initial read, clean on every transition.
- [x] Repair flow appears and completes end-to-end (token refreshed, device restarts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)