### PR TITLE
Fix max SOC configuration using dead REST endpoint (closes #34)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -77,5 +77,8 @@
   },
   "1.1.19": {
     "en": "Deprecate non-functional start/stop charging cards (#32); fix window/sunroof status detection for vehicles that don't report rear windows, e.g. V-Klasse (#31)"
+  },
+  "1.1.20": {
+    "en": "Fix 'Set maximum charge level' flow card failing with 'API Error: Not Found' (#34) by sending it over the vehicle command channel; remove the unsupported charge program requirement"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.mercedes.mbapi",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [

--- a/.homeycompose/flow/actions/configure_max_soc.json
+++ b/.homeycompose/flow/actions/configure_max_soc.json
@@ -5,9 +5,9 @@
     "de": "Maximalen Ladestand einstellen"
   },
   "titleFormatted": {
-    "en": "Set maximum charge to [[max_soc]]% for [[charge_program]]",
-    "nl": "Stel maximale lading in op [[max_soc]]% voor [[charge_program]]",
-    "de": "Maximale Ladung auf [[max_soc]]% für [[charge_program]] einstellen"
+    "en": "Set maximum charge to [[max_soc]]%",
+    "nl": "Stel maximale lading in op [[max_soc]]%",
+    "de": "Maximale Ladung auf [[max_soc]]% einstellen"
   },
   "hint": {
     "en": "Sets the maximum battery charge level (state of charge) for the vehicle.",
@@ -28,44 +28,9 @@
         "nl": "Maximaal laden %",
         "de": "Maximale Ladung %"
       },
-      "min": 50,
+      "min": 30,
       "max": 100,
       "step": 10
-    },
-    {
-      "type": "dropdown",
-      "name": "charge_program",
-      "title": {
-        "en": "Charge program",
-        "nl": "Laadprogramma",
-        "de": "Ladeprogramm"
-      },
-      "values": [
-        {
-          "id": "0",
-          "label": {
-            "en": "Default",
-            "nl": "Standaard",
-            "de": "Standard"
-          }
-        },
-        {
-          "id": "2",
-          "label": {
-            "en": "Home",
-            "nl": "Thuis",
-            "de": "Zuhause"
-          }
-        },
-        {
-          "id": "3",
-          "label": {
-            "en": "Work",
-            "nl": "Werk",
-            "de": "Arbeit"
-          }
-        }
-      ]
     }
   ]
 }

--- a/app.json
+++ b/app.json
@@ -996,9 +996,9 @@
           "de": "Maximalen Ladestand einstellen"
         },
         "titleFormatted": {
-          "en": "Set maximum charge to [[max_soc]]% for [[charge_program]]",
-          "nl": "Stel maximale lading in op [[max_soc]]% voor [[charge_program]]",
-          "de": "Maximale Ladung auf [[max_soc]]% für [[charge_program]] einstellen"
+          "en": "Set maximum charge to [[max_soc]]%",
+          "nl": "Stel maximale lading in op [[max_soc]]%",
+          "de": "Maximale Ladung auf [[max_soc]]% einstellen"
         },
         "hint": {
           "en": "Sets the maximum battery charge level (state of charge) for the vehicle.",
@@ -1019,44 +1019,9 @@
               "nl": "Maximaal laden %",
               "de": "Maximale Ladung %"
             },
-            "min": 50,
+            "min": 30,
             "max": 100,
             "step": 10
-          },
-          {
-            "type": "dropdown",
-            "name": "charge_program",
-            "title": {
-              "en": "Charge program",
-              "nl": "Laadprogramma",
-              "de": "Ladeprogramm"
-            },
-            "values": [
-              {
-                "id": "0",
-                "label": {
-                  "en": "Default",
-                  "nl": "Standaard",
-                  "de": "Standard"
-                }
-              },
-              {
-                "id": "2",
-                "label": {
-                  "en": "Home",
-                  "nl": "Thuis",
-                  "de": "Zuhause"
-                }
-              },
-              {
-                "id": "3",
-                "label": {
-                  "en": "Work",
-                  "nl": "Werk",
-                  "de": "Arbeit"
-                }
-              }
-            ]
           }
         ],
         "id": "configure_max_soc"

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.mercedes.mbapi",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [

--- a/drivers/mercedes-vehicle/device.js
+++ b/drivers/mercedes-vehicle/device.js
@@ -1856,13 +1856,12 @@ class MercedesVehicleDevice extends Homey.Device {
 
   /**
    * Flow action: Configure maximum state of charge
-   * @param {number} maxSoc - Maximum state of charge percentage (50-100)
-   * @param {string} chargeProgram - Charge program ID (0=Default, 2=Home, 3=Work)
+   * @param {number} maxSoc - Maximum state of charge percentage
    */
-  async configureMaxSocAction(maxSoc, chargeProgram) {
-    this.log(`[FLOW] Configure max SOC action: ${maxSoc}%, program=${chargeProgram}`);
+  async configureMaxSocAction(maxSoc) {
+    this.log(`[FLOW] Configure max SOC action: ${maxSoc}%`);
     try {
-      await this.api.configureBatteryMaxSoc(this.vin, maxSoc, parseInt(chargeProgram, 10));
+      await this.api.configureBatteryMaxSoc(this.vin, maxSoc);
       this.log('[FLOW] Max SOC configured successfully');
       return true;
     } catch (error) {

--- a/drivers/mercedes-vehicle/driver.js
+++ b/drivers/mercedes-vehicle/driver.js
@@ -187,7 +187,7 @@ class MercedesVehicleDriver extends Homey.Driver {
       this.homey.flow.getActionCard('configure_max_soc')
         .registerRunListener(async (args) => {
           this.log('[FLOW] Configure max SoC action triggered');
-          await args.device.configureMaxSocAction(args.max_soc, args.charge_program);
+          await args.device.configureMaxSocAction(args.max_soc);
           return true;
         });
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -339,11 +339,10 @@ class MercedesAPI {
   /**
    * Configure battery max state of charge
    */
-  async configureBatteryMaxSoc(vin, maxSoc, chargeProgram = 0) {
-    return await this._sendCommand(vin, 'charge/max-soc', {
-      max_soc: maxSoc,
-      charge_program: chargeProgram
-    });
+  async configureBatteryMaxSoc(vin, maxSoc) {
+    this.homey.app.log(`[API] Configuring max SOC for vehicle ${vin}: ${maxSoc}%`);
+    const { buffer, requestId } = this.protoParser.createConfigureMaxSocCommand(vin, maxSoc);
+    return await this.websocket.sendCommand(buffer, requestId);
   }
 
   /**

--- a/lib/proto/parser.js
+++ b/lib/proto/parser.js
@@ -705,6 +705,18 @@ class ProtoParser {
       chargeStop: {}
     });
   }
+
+  /**
+   * Create configure battery max state-of-charge command
+   * @param {String} vin - Vehicle VIN
+   * @param {Number} maxSoc - Maximum state of charge percentage
+   * @returns {Object} {buffer: Buffer, requestId: String}
+   */
+  createConfigureMaxSocCommand(vin, maxSoc) {
+    return this._createCommandMessage(vin, {
+      batteryMaxSoc: { maxSoc: maxSoc }
+    });
+  }
 }
 
 module.exports = ProtoParser;

--- a/lib/proto/vehicle-commands.proto
+++ b/lib/proto/vehicle-commands.proto
@@ -97,6 +97,11 @@ message ChargeStart {
 message ChargeStop {
 }
 
+// Battery max state-of-charge configuration
+message BatteryMaxSocConfigure {
+  int32 max_soc = 1;
+}
+
 // Seat heating configuration
 message PrecondSeatConfigure {
   bool front_left = 1;
@@ -157,5 +162,6 @@ message CommandRequest {
     PrecondSeatConfigure precond_seat_configure = 26;
     ChargeStart charge_start = 30;
     ChargeStop charge_stop = 31;
+    BatteryMaxSocConfigure battery_max_soc = 28;
   }
 }


### PR DESCRIPTION
## Summary
- `configureBatteryMaxSoc` was the only vehicle command still posting to a legacy REST endpoint (`/v1/vehicle/{vin}/command/charge/max-soc`), which no longer exists on Mercedes' backend (404 Not Found)
- Migrated it to the same protobuf `CommandRequest` / websocket channel every other vehicle command uses, adding the `BatteryMaxSocConfigure` message (field 28)
- Removed the unsupported `charge_program` argument from the "Set maximum charge level" flow card and lowered the minimum from 50% to 30% to match the Mercedes app
- Bumped version to 1.1.20 and published test build 29

## Test plan
- [x] Published test build (ID 29) and verified the "Set maximum charge level" flow card succeeds against a real vehicle