### PR TITLE
Add GitHub Actions workflows for Homey app validate/version/publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
     name: Publish Homey App
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Publish
         uses: athombv/github-action-homey-app-publish@master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish Homey App
+on:
+  workflow_dispatch:
+
+jobs:
+  main:
+    name: Publish Homey App
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish
+        uses: athombv/github-action-homey-app-publish@master
+        id: publish
+        with:
+          personal_access_token: ${{ secrets.HOMEY_PAT }}
+
+      - name: URL
+        run: |
+          echo "Manage your app at ${{ steps.publish.outputs.url }}." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,15 @@
+name: Validate Homey App
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+  main:
+    name: Validate Homey App
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: athombv/github-action-homey-app-validate@master
+        with:
+          level: publish

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ jobs:
     name: Validate Homey App
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: athombv/github-action-homey-app-validate@master
         with:
           level: publish

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,50 @@
+name: Update Homey App Version
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: choice
+        description: Version
+        required: true
+        default: patch
+        options:
+          - major
+          - minor
+          - patch
+      changelog:
+        type: string
+        description: Changelog
+        required: true
+
+# Needed in order to push the commit and create a release
+permissions:
+  contents: write
+
+jobs:
+  main:
+    name: Update Homey App Version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update Homey App Version
+        uses: athombv/github-action-homey-app-version@master
+        id: update_app_version
+        with:
+          version: ${{ inputs.version }}
+          changelog: ${{ inputs.changelog }}
+
+      - name: Commit & Push
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          git commit -m "Update Homey App Version to v${{ steps.update_app_version.outputs.version }}"
+          git tag "v${{ steps.update_app_version.outputs.version }}"
+
+          git push origin HEAD --tags
+          gh release create "v${{ steps.update_app_version.outputs.version }}" -t "v${{ steps.update_app_version.outputs.version }}" --notes "" --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -25,7 +25,7 @@ jobs:
     name: Update Homey App Version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Update Homey App Version
         uses: athombv/github-action-homey-app-version@master


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/validate.yml` — runs `homey app validate --level publish` on every push/PR plus manual dispatch
- Adds `.github/workflows/version.yml` — manual dispatch to bump the app version (major/minor/patch), commit, tag, and create a GitHub release
- Adds `.github/workflows/publish.yml` — manual dispatch to publish the app to the Homey App Store (uses the `HOMEY_PAT` repo secret, already configured)
- Uses `actions/checkout@v5` throughout to avoid the Node.js 20 deprecation warning

Based on Homey's official ["Automating within GitHub Actions"](https://apps.developer.homey.app/app-store/publishing#automating-within-github-actions) guide, using Athom's own reference templates.

## Test plan
- [x] Ran `npx homey app validate --level publish` locally — passes
- [x] Triggered the `validate.yml` workflow manually in GitHub Actions — passes cleanly with no warnings
- [ ] Manually trigger `version.yml` / `publish.yml` when ready to cut an actual release

🤖 Generated with [Claude Code](https://claude.com/claude-code)