### PR TITLE
Add region selection to pairing flow (closes #36)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish Homey App
+on:
+  workflow_dispatch:
+
+jobs:
+  main:
+    name: Publish Homey App
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Publish
+        uses: athombv/github-action-homey-app-publish@master
+        id: publish
+        with:
+          personal_access_token: ${{ secrets.HOMEY_PAT }}
+
+      - name: URL
+        run: |
+          echo "Manage your app at ${{ steps.publish.outputs.url }}." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,15 @@
+name: Validate Homey App
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+  main:
+    name: Validate Homey App
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: athombv/github-action-homey-app-validate@master
+        with:
+          level: publish

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,50 @@
+name: Update Homey App Version
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: choice
+        description: Version
+        required: true
+        default: patch
+        options:
+          - major
+          - minor
+          - patch
+      changelog:
+        type: string
+        description: Changelog
+        required: true
+
+# Needed in order to push the commit and create a release
+permissions:
+  contents: write
+
+jobs:
+  main:
+    name: Update Homey App Version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Update Homey App Version
+        uses: athombv/github-action-homey-app-version@master
+        id: update_app_version
+        with:
+          version: ${{ inputs.version }}
+          changelog: ${{ inputs.changelog }}
+
+      - name: Commit & Push
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          git commit -m "Update Homey App Version to v${{ steps.update_app_version.outputs.version }}"
+          git tag "v${{ steps.update_app_version.outputs.version }}"
+
+          git push origin HEAD --tags
+          gh release create "v${{ steps.update_app_version.outputs.version }}" -t "v${{ steps.update_app_version.outputs.version }}" --notes "" --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}

--- a/app.json
+++ b/app.json
@@ -1613,8 +1613,7 @@
       ],
       "pair": [
         {
-          "id": "login_credentials",
-          "template": "login_credentials"
+          "id": "login_credentials"
         },
         {
           "id": "list_devices",

--- a/drivers/mercedes-vehicle/driver.compose.json
+++ b/drivers/mercedes-vehicle/driver.compose.json
@@ -75,8 +75,7 @@
   ],
   "pair": [
     {
-      "id": "login_credentials",
-      "template": "login_credentials"
+      "id": "login_credentials"
     },
     {
       "id": "list_devices",

--- a/drivers/mercedes-vehicle/driver.js
+++ b/drivers/mercedes-vehicle/driver.js
@@ -295,14 +295,34 @@ class MercedesVehicleDriver extends Homey.Driver {
   }
 
   /**
+   * Pre-select a likely Mercedes me account region from the Homey's timezone.
+   * This is only a starting point for the pair view's dropdown — the account
+   * region is where the Mercedes me account was registered, not where the
+   * Homey physically sits, so the user must be able to override it.
+   */
+  _defaultRegionFromTimezone(tz) {
+    if (tz === 'Asia/Shanghai' || tz === 'Asia/Urumqi') return 'China';
+    if (tz && tz.startsWith('America/')) return 'North America';
+    if (tz && (tz.startsWith('Australia/') || tz.startsWith('Pacific/') || tz.startsWith('Asia/'))) {
+      return 'Asia-Pacific';
+    }
+    return 'Europe'; // Europe/*, Africa/*, Atlantic/*, and fallback
+  }
+
+  /**
    * onPair is called when a user starts pairing
    */
   async onPair(session) {
     let credentials = {};
-    const region = 'Europe'; // Default to Europe region
+    let region = 'Europe';
     let oauth = null;
     let vehicles = [];
     let deviceGuid = null;
+
+    // Provide a sensible default for the pair view's region dropdown
+    session.setHandler('get_default_region', async () => {
+      return this._defaultRegionFromTimezone(this.homey.clock.getTimezone());
+    });
 
     // Handle login credentials
     session.setHandler('login', async (data) => {
@@ -313,8 +333,10 @@ class MercedesVehicleDriver extends Homey.Driver {
         password: data.password
       };
 
+      region = Object.keys(MercedesOAuth.ENDPOINTS).includes(data.region) ? data.region : 'Europe';
+
       try {
-        // Initialize OAuth with Europe region and generate persistent deviceGuid
+        // Initialize OAuth with the selected region and generate a persistent deviceGuid
         oauth = new MercedesOAuth(this.homey, region);
         deviceGuid = oauth.deviceGuid; // Store for later use
 
@@ -331,6 +353,11 @@ class MercedesVehicleDriver extends Homey.Driver {
           if (vehicleError.message && (vehicleError.message.includes('418') || vehicleError.message.includes('status code 418'))) {
             this.error('Rate limited by Mercedes API');
             throw new Error('Too many requests. Please wait 15-30 minutes and try again.');
+          }
+          // A 404 here means login succeeded but the region's backend has
+          // no record of this account — almost always a region mismatch.
+          if (vehicleError.message && (vehicleError.message.includes('404') || vehicleError.message.includes('status code 404'))) {
+            throw new Error(this.homey.__('pair.vehicles_region_mismatch', { region }));
           }
           throw vehicleError;
         }
@@ -357,7 +384,7 @@ class MercedesVehicleDriver extends Homey.Driver {
       this.log('list_devices called, returning', vehicles.length, 'vehicles');
 
       if (!vehicles || vehicles.length === 0) {
-        throw new Error(this.homey.__('pair.no_vehicles_found'));
+        throw new Error(this.homey.__('pair.no_vehicles_found', { region }));
       }
 
       return vehicles.map(vehicle => {

--- a/drivers/mercedes-vehicle/pair/login_credentials.html
+++ b/drivers/mercedes-vehicle/pair/login_credentials.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+</head>
+<body>
+  <form class="homey-form" id="login_form">
+    <div class="homey-form-group">
+      <label class="homey-form-label" for="username" data-i18n="pair.login_credentials.username"></label>
+      <input class="homey-form-input" id="username" type="text" autocomplete="username" required>
+    </div>
+
+    <div class="homey-form-group">
+      <label class="homey-form-label" for="password" data-i18n="pair.login_credentials.password"></label>
+      <input class="homey-form-input" id="password" type="password" autocomplete="current-password" required>
+    </div>
+
+    <div class="homey-form-group">
+      <label class="homey-form-label" for="region" data-i18n="pair.login_credentials.region"></label>
+      <select class="homey-form-select" id="region">
+        <option value="Europe" data-i18n="pair.login_credentials.region_europe"></option>
+        <option value="North America" data-i18n="pair.login_credentials.region_north_america"></option>
+        <option value="Asia-Pacific" data-i18n="pair.login_credentials.region_asia_pacific"></option>
+        <option value="China" data-i18n="pair.login_credentials.region_china"></option>
+      </select>
+      <p class="homey-form-hint" data-i18n="pair.login_credentials.region_hint"></p>
+    </div>
+
+    <button class="homey-button-primary-full" id="login_button" type="submit" data-i18n="pair.login_credentials.submit"></button>
+  </form>
+
+  <script type="text/javascript">
+    function onHomeyReady(Homey) {
+      Homey.setTitle(Homey.__('pair.login_credentials.title'));
+
+      const form = document.getElementById('login_form');
+      const regionSelect = document.getElementById('region');
+
+      // Pre-select a likely region based on the Homey's timezone.
+      // The user can always override it — the account region is where
+      // the Mercedes me account was registered, not where the Homey is.
+      Homey.emit('get_default_region')
+        .then(function (defaultRegion) {
+          if (defaultRegion) {
+            regionSelect.value = defaultRegion;
+          }
+        })
+        .catch(function () {
+          // Ignore — keep the select's own default (Europe)
+        });
+
+      form.addEventListener('submit', function (event) {
+        event.preventDefault();
+
+        const username = document.getElementById('username').value;
+        const password = document.getElementById('password').value;
+        const region = regionSelect.value;
+
+        Homey.showLoadingOverlay();
+
+        Homey.emit('login', { username: username, password: password, region: region })
+          .then(function () {
+            Homey.hideLoadingOverlay();
+            Homey.nextView();
+          })
+          .catch(function (err) {
+            Homey.hideLoadingOverlay();
+            Homey.alert(err.message || err);
+          });
+      });
+
+      Homey.ready();
+    }
+  </script>
+</body>
+</html>

--- a/locales/en.json
+++ b/locales/en.json
@@ -2,7 +2,20 @@
   "pair": {
     "login_failed": "Login failed. Please check your credentials and try again.",
     "fetch_vehicles_failed": "Failed to fetch vehicles. Please try again.",
-    "no_vehicles_found": "No vehicles found on your account."
+    "no_vehicles_found": "No vehicles were found in the __region__ region. Verify the region matches where your Mercedes me account was registered, and that this account is the vehicle's admin/owner.",
+    "vehicles_region_mismatch": "Login succeeded, but the vehicle lookup failed for the __region__ region. Your Mercedes me account may be registered in a different region — please try again with the correct region selected.",
+    "login_credentials": {
+      "title": "Log in to Mercedes me",
+      "username": "Email",
+      "password": "Password",
+      "region": "Region",
+      "region_hint": "Select the region where your Mercedes me account was registered — this may differ from where you live.",
+      "region_europe": "Europe",
+      "region_north_america": "North America",
+      "region_asia_pacific": "Asia-Pacific",
+      "region_china": "China",
+      "submit": "Log in"
+    }
   },
   "error": {
     "auth_failed": "Authentication failed. Please re-add the device.",


### PR DESCRIPTION
## Summary
- Adds region selection to the pairing flow so non-European accounts can select their region and successfully discover devices (fixes #36)
- Adds GitHub Actions workflows for validate/version/publish automation (merged in via #37)

🤖 Generated with [Claude Code](https://claude.com/claude-code)