### PR TITLE
Add charging animation sweep to battery bar in car-status widget

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,6 +53,7 @@ class MercedesMeApp extends Homey.App {
         rearRight: getValue('window_rear_right'),
       },
       sunroof: getValue('window_sunroof'),
+      charging: getValue('onoff_charging'),
       chargingStatus: getValue('text_charging_status'),
       engineRunning: getValue('engine_running'),
       climateOn: getValue('climate_active'),

--- a/widgets/car-status/public/index.html
+++ b/widgets/car-status/public/index.html
@@ -77,6 +77,48 @@
   .energy-bar-fill.battery { background: var(--color-blue); }
   .energy-bar-fill.fuel { background: var(--color-fuel); }
 
+  .energy-bar-fill.battery {
+    position: relative;
+    overflow: hidden;
+  }
+
+  .energy-bar-fill.battery::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: repeating-linear-gradient(
+      100deg,
+      transparent 0%,
+      transparent 8%,
+      rgba(255, 255, 255, 0.65) 11%,
+      transparent 15%,
+      transparent 100%
+    );
+    background-size: 240% 100%;
+    background-position: 0% 0;
+    mix-blend-mode: screen;
+    opacity: 0;
+    transition: opacity 0.25s ease;
+  }
+
+  .energy-bar-fill.battery.charging::after {
+    opacity: 1;
+    animation: chase 4.4s linear infinite;
+  }
+
+  @keyframes chase {
+    from { background-position: 0% 0; }
+    to   { background-position: -240% 0; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .energy-bar-fill.battery.charging::after {
+      animation: none;
+      opacity: 0.55;
+      background-position: -60% 0;
+    }
+  }
+
   .energy-value {
     font-size: 11px;
     color: var(--color-text-secondary);
@@ -290,6 +332,7 @@
       batteryRow.classList.remove('hidden');
       var pct = data.battery || 0;
       document.getElementById('batteryBar').style.width = pct + '%';
+      document.getElementById('batteryBar').classList.toggle('charging', data.charging === true);
       var batteryText = pct + '%';
       if (hasRangeElectric) batteryText += ' \u00B7 ' + Math.round(data.rangeElectric) + ' km';
       document.getElementById('batteryValue').textContent = batteryText;


### PR DESCRIPTION
## Summary
- Surfaces `onoff_charging` as a boolean `charging` field from `app.js`'s `getDeviceStatus()`
- Adds a CSS light-sweep animation (`chase`, 4.4s loop) to the `.energy-bar-fill.battery` element, clipped to the filled width via `position: relative; overflow: hidden`
- Toggles the `.charging` class on `#batteryBar` based on `data.charging` in the widget's `update()` function
- Respects `prefers-reduced-motion` by disabling the animation and showing a static dimmed sweep instead
- Fuel bar (`.energy-bar-fill.fuel`) is untouched

Design was pre-validated in a mockup (4.4s loop speed confirmed) referenced in the issue. `.homeycompose` gitignore request from the issue was intentionally skipped — that folder is the hand-maintained compose source that `app.json` is generated from, not a build artifact.

Closes #40

## Test plan
- [x] `npx homey app build` validates successfully
- [x] Verified sweep animation visually in a standalone browser test (sweep clipped to blue fill only, fuel bar unaffected, sweeps only when `.charging` class present)
- [ ] Verify against live widget with a vehicle in charging vs non-charging state