### PR TITLE
Improve error messaging for login failures with missing result field

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -89,5 +89,8 @@
   },
   "1.1.23": {
     "en": "Add charging animation sweep to battery bar in car-status widget"
+  },
+  "1.1.24": {
+    "en": "Fix login failing with 'Unexpected login result: undefined' by handling Mercedes' passkey/biometric setup prompt during login"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.mercedes.mbapi",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.mercedes.mbapi",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -412,20 +412,29 @@ class MercedesOAuth {
       let preLoginData = await this._submitPassword(email, password);
 
       // Check result and handle special cases
-      if (preLoginData.result !== 'RESUME2OIDCP') {
-        if (preLoginData.result === 'GOTO_LOGIN_OTP') {
+      if (!preLoginData || preLoginData.result !== 'RESUME2OIDCP') {
+        if (preLoginData && preLoginData.result === 'GOTO_LOGIN_OTP') {
           throw new Error('Two-factor authentication (2FA) is not supported. Please disable 2FA on your Mercedes Me account.');
         }
 
-        if (preLoginData.result === 'GOTO_LOGIN_LEGAL_TEXTS') {
+        if (preLoginData && preLoginData.result === 'GOTO_LOGIN_LEGAL_TEXTS') {
           this.homey.app.log('Legal consent required');
           const homeCountry = preLoginData.homeCountry || '';
           const consentCountry = preLoginData.consentCountry || '';
           preLoginData = await this._submitLegalConsent(homeCountry, consentCountry);
 
-          if (preLoginData.result !== 'RESUME2OIDCP') {
+          if (!preLoginData || preLoginData.result !== 'RESUME2OIDCP') {
             throw new Error('Problem accepting legal terms during login');
           }
+        } else if (!preLoginData || !preLoginData.result) {
+          // Mercedes accepted the HTTP request but returned no usable "result" field.
+          // This is most commonly caused by invalid credentials or anti-automation
+          // detection on the login endpoint, rather than a network/API error.
+          this.homey.app.error(
+            'Login response missing "result" field. Response keys:',
+            preLoginData && typeof preLoginData === 'object' ? Object.keys(preLoginData) : typeof preLoginData
+          );
+          throw new Error('Login failed: Mercedes-Benz did not accept your email/password. Please verify your credentials in the Mercedes Me app and try again.');
         } else {
           throw new Error(`Unexpected login result: ${preLoginData.result}`);
         }

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -243,16 +243,21 @@ class MercedesOAuth {
   }
 
   /**
-   * Step 4: Submit password and get pre-login token
-   * Matches HA: async def _submit_password(self, email: str, password: str)
+   * Generate random request id used for password submission and passkey-demo skip
+   * Matches HA: rid = secrets.token_urlsafe(24)
    */
-  async _submitPassword(email, password) {
-    // Generate random ID (matches HA: rid = secrets.token_urlsafe(24))
-    const rid = crypto.randomBytes(24).toString('base64')
+  _generateRid() {
+    return crypto.randomBytes(24).toString('base64')
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
       .replace(/=/g, '');
+  }
 
+  /**
+   * Step 4: Submit password and get pre-login token
+   * Matches HA: async def _submit_password(self, email: str, password: str, rid: str)
+   */
+  async _submitPassword(email, password, rid) {
     const headers = this._getMobileSafariHeaders();
 
     const data = {
@@ -279,7 +284,38 @@ class MercedesOAuth {
   }
 
   /**
-   * Step 4b: Submit legal consent (if required)
+   * Step 4b: Decline the passkey/biometric setup prompt (if the account is offered one)
+   * Matches HA: async def _disable_passkey_demo(self, email: str, password: str, rid: str)
+   */
+  async _disablePasskeyDemo(email, password, rid) {
+    const headers = this._getMobileSafariHeaders();
+
+    const data = {
+      username: email,
+      password: password,
+      rememberMe: false,
+      rid: rid,
+      disablePasskeyDemo: true
+    };
+
+    const url = `${this.endpoints.login}/ciam/auth/disablePasskeyDemo`;
+
+    try {
+      const response = await this.client.post(url, data, { headers });
+      this.homey.app.log('Passkey setup prompt declined');
+      return response.data;
+    } catch (error) {
+      this.homey.app.error('Passkey prompt skip error:', {
+        status: error.response?.status,
+        statusText: error.response?.statusText,
+        data: error.response?.data
+      });
+      throw new Error(`Passkey prompt skip failed: ${error.message}`);
+    }
+  }
+
+  /**
+   * Step 4c: Submit legal consent (if required)
    * Matches HA: async def _submit_legal_consent(self, home_country: str, consent_country: str)
    */
   async _submitLegalConsent(homeCountry, consentCountry) {
@@ -409,7 +445,17 @@ class MercedesOAuth {
       await this._submitUsername(email);
 
       // Step 4: Submit password and get pre-login data
-      let preLoginData = await this._submitPassword(email, password);
+      const rid = this._generateRid();
+      let preLoginData = await this._submitPassword(email, password, rid);
+
+      // Step 4b: Decline the passkey/biometric setup prompt if the account gets offered one.
+      // When this prompt is present, the response has no "result" field at all (only
+      // "passkeyDemoEnabled": true), which previously surfaced as "Unexpected login
+      // result: undefined" instead of being handled.
+      if (preLoginData && preLoginData.passkeyDemoEnabled) {
+        this.homey.app.log('Passkey setup prompt detected - declining to continue password login');
+        preLoginData = await this._disablePasskeyDemo(email, password, rid);
+      }
 
       // Check result and handle special cases
       if (!preLoginData || preLoginData.result !== 'RESUME2OIDCP') {


### PR DESCRIPTION
## Summary

Fixes the `Unexpected login result: undefined` error reported in a user log (closes #42).

- **Root cause fix**: added the missing passkey/biometric setup-prompt handling from the upstream [mbapi2020](https://github.com/ReneNulschDE/mbapi2020) reference implementation. After password submission, Mercedes can respond with `"passkeyDemoEnabled": true` instead of a `result` field (offering a passkey/biometric login setup). That response has no `result` key at all, which is exactly why `preLoginData.result` evaluated to `undefined`. This port never handled that response shape — it now declines the prompt via `POST /ciam/auth/disablePasskeyDemo` (mirroring `_disable_passkey_demo` upstream) before continuing the login flow.
- **Defensive/diagnostic improvement**: for any other case where the response genuinely lacks a `result` field (e.g. invalid credentials, anti-automation detection), `login()` now surfaces an actionable message instead of the cryptic `Unexpected login result: undefined`, and logs the response's key shape so future occurrences are diagnosable from Homey logs. Added `preLoginData` null/type guards around each `result` comparison to avoid an unrelated `TypeError` if a response body is ever missing entirely.

## Root cause

`lib/oauth.js`'s `login()` only recognized three known `result` values (`RESUME2OIDCP`, `GOTO_LOGIN_OTP`, `GOTO_LOGIN_LEGAL_TEXTS`). It was missing the upstream `passkeyDemoEnabled` intermediate step entirely, so accounts being offered a passkey/biometric setup prompt during login always failed with `Unexpected login result: undefined` — there is no generic "unexpected result" to report, it's a distinct step that was never implemented.

## Test plan

- [x] `node -c lib/oauth.js` (syntax check — no test suite exists in this repo)
- [x] Verified the missing step by diffing against the current upstream `oauth.py` source
- [ ] Manual verification against a real Mercedes account that gets the passkey prompt would further confirm the fix, but the trigger is server-side and account-specific, so it can't be reliably reproduced locally.
