### PR TITLE
Fix vehicle-data polling for non-Europe regions (issue #36)

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -128,8 +128,7 @@ class MercedesAPI {
       // HA implementation: https://widget.emea-prod.mobilesdk.mercedes-benz.com/v1/vehicle/{vin}/vehicleattributes
       // Returns protobuf data (VEPUpdate message)
       const headers = await this._getHeaders();
-      const widgetUrl = this.endpoints.rest.replace('bff.emea-prod', 'widget.emea-prod');
-      const url = `${widgetUrl}/v1/vehicle/${vin}/vehicleattributes`;
+      const url = `${this.endpoints.widget}/v1/vehicle/${vin}/vehicleattributes`;
 
       this.homey.app.log(`[API] Fetching vehicle data from: ${url}`);
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -22,21 +22,25 @@ class MercedesOAuth {
     'Europe': {
       login: 'https://id.mercedes-benz.com',
       rest: 'https://bff.emea-prod.mobilesdk.mercedes-benz.com',
+      widget: 'https://widget.emea-prod.mobilesdk.mercedes-benz.com',
       websocket: 'wss://websocket.emea-prod.mobilesdk.mercedes-benz.com/v2/ws'
     },
     'North America': {
       login: 'https://id.mercedes-benz.com',
       rest: 'https://bff.amap-prod.mobilesdk.mercedes-benz.com',
+      widget: 'https://widget.amap-prod.mobilesdk.mercedes-benz.com',
       websocket: 'wss://websocket.amap-prod.mobilesdk.mercedes-benz.com/v2/ws'
     },
     'Asia-Pacific': {
       login: 'https://id.mercedes-benz.com',
       rest: 'https://bff.amap-prod.mobilesdk.mercedes-benz.com',
+      widget: 'https://widget.amap-prod.mobilesdk.mercedes-benz.com',
       websocket: 'wss://websocket.amap-prod.mobilesdk.mercedes-benz.com/v2/ws'
     },
     'China': {
       login: 'https://ciam-1.mercedes-benz.com.cn',
       rest: 'https://bff.cn-prod.mobilesdk.mercedes-benz.com',
+      widget: 'https://widget.cn-prod.mobilesdk.mercedes-benz.com',
       websocket: 'wss://websocket.cn-prod.mobilesdk.mercedes-benz.com/v2/ws'
     }
   };


### PR DESCRIPTION
## Summary
- Fixes the follow-on bug behind the reopened #36: pairing now correctly selects a region (#38), but `getVehicleData()` in `lib/api.js` derived its widget-subdomain host with `this.endpoints.rest.replace('bff.emea-prod', 'widget.emea-prod')` — a substring that only exists for the Europe endpoint. For North America, Asia-Pacific, and China accounts the `.replace()` was a silent no-op, so every poll cycle hit the wrong (`bff.*`) host instead of `widget.*`.
- Non-European devices could therefore pair successfully (login/`getVehicles()` already used the region's `rest` endpoint directly) but would never receive live vehicle data afterward.
- Adds an explicit `widget` URL per region to `MercedesOAuth.ENDPOINTS` (`lib/oauth.js`) and has `getVehicleData()` read `this.endpoints.widget` directly instead of deriving it via string substitution.

Diagnosis and fix plan were posted to [#36](https://github.com/andersdissing/Mercedes-Benz-homey-app/issues/36#issuecomment-5048293623) before implementing.

Originally branched on top of `claude/mercedes-init-error-mnip1o` (#43) since both touched `lib/oauth.js`/`lib/api.js`; now that #43 is merged into `main`, this PR is rebased onto `main` and scoped to just the two files above.

## Test plan
- [x] `node -c lib/oauth.js && node -c lib/api.js` — syntax check
- [x] `npx homey app validate` — passes at `publish` level
- [ ] Manual verification against a real non-Europe (NA/APAC/China) Mercedes account would further confirm the fix, but the trigger is account-region-specific and can't be reliably reproduced locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)