### PR TITLE
Fix pairing login form submission and WebSocket ReferenceError

### DIFF
--- a/drivers/mercedes-vehicle/pair/login_credentials.html
+++ b/drivers/mercedes-vehicle/pair/login_credentials.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
 </head>
 <body>
-  <form class="homey-form" id="login_form">
+  <form class="homey-form" id="login_form" onsubmit="handleLogin(event)">
     <div class="homey-form-group">
       <label class="homey-form-label" for="username" data-i18n="pair.login_credentials.username"></label>
       <input class="homey-form-input" id="username" type="text" autocomplete="username" required>
@@ -30,46 +30,42 @@
   </form>
 
   <script type="text/javascript">
-    function onHomeyReady(Homey) {
-      Homey.setTitle(Homey.__('pair.login_credentials.title'));
+    Homey.setTitle(Homey.__('pair.login_credentials.title'));
 
-      const form = document.getElementById('login_form');
-      const regionSelect = document.getElementById('region');
+    const form = document.getElementById('login_form');
+    const regionSelect = document.getElementById('region');
 
-      // Pre-select a likely region based on the Homey's timezone.
-      // The user can always override it — the account region is where
-      // the Mercedes me account was registered, not where the Homey is.
-      Homey.emit('get_default_region')
-        .then(function (defaultRegion) {
-          if (defaultRegion) {
-            regionSelect.value = defaultRegion;
-          }
-        })
-        .catch(function () {
-          // Ignore — keep the select's own default (Europe)
-        });
-
-      form.addEventListener('submit', function (event) {
-        event.preventDefault();
-
-        const username = document.getElementById('username').value;
-        const password = document.getElementById('password').value;
-        const region = regionSelect.value;
-
-        Homey.showLoadingOverlay();
-
-        Homey.emit('login', { username: username, password: password, region: region })
-          .then(function () {
-            Homey.hideLoadingOverlay();
-            Homey.nextView();
-          })
-          .catch(function (err) {
-            Homey.hideLoadingOverlay();
-            Homey.alert(err.message || err);
-          });
+    // Pre-select a likely region based on the Homey's timezone.
+    // The user can always override it — the account region is where
+    // the Mercedes me account was registered, not where the Homey is.
+    Homey.emit('get_default_region')
+      .then(function (defaultRegion) {
+        if (defaultRegion) {
+          regionSelect.value = defaultRegion;
+        }
+      })
+      .catch(function () {
+        // Ignore — keep the select's own default (Europe)
       });
 
-      Homey.ready();
+    function handleLogin(event) {
+      event.preventDefault();
+
+      const username = document.getElementById('username').value;
+      const password = document.getElementById('password').value;
+      const region = regionSelect.value;
+
+      Homey.showLoadingOverlay();
+
+      Homey.emit('login', { username: username, password: password, region: region })
+        .then(function() {
+          Homey.hideLoadingOverlay();
+          Homey.nextView();
+        })
+        .catch(function (err) {
+          Homey.hideLoadingOverlay();
+          Homey.alert(err.message || err);
+        });
     }
   </script>
 </body>

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -665,7 +665,7 @@ class MercedesWebSocket {
     }
 
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-      this.messageHandler = savedHandler;
+      this.messageHandler = originalHandler;
       throw new Error('WebSocket connection not available for command');
     }
 


### PR DESCRIPTION
Hi Anders,

First of all, thank you so much for creating and maintaining this Mercedes-Benz Homey app! I really appreciate the hard work you've put into this project.

When I tried setting up the app for my vehicle, I ran into an issue where the login form in the pairing wizard didn't submit properly. After digging into the codebase and testing locally, I managed to get it working smoothly for my setup. As a thank you for your great work on this app, I wanted to share these fixes back with you!

If you have any feedback, questions, or review comments, please let me know — I'm more than happy to make any adjustments or improvements! Of course, if you have different ideas or alternative approaches for handling these parts, feel free to adjust as you see fit as well.

## Summary of Changes

1. **Fix custom pair view form submission (`drivers/mercedes-vehicle/pair/login_credentials.html`)**:
   - Replaced the `onHomeyReady` wrapper with an explicit `onsubmit="handleLogin(event)"` handler on the login form.
   - Ensures credentials and selected region (`Europe`, `North America`, `Asia-Pacific`, `China`) are reliably emitted to `driver.js` when the user submits the form.

2. **Fix `ReferenceError: savedHandler is not defined` (`lib/websocket.js`)**:
   - Fixed variable name in `sendCommand` error recovery path where `savedHandler` was referenced instead of `originalHandler` (from a previous refactoring).

Tested and verified locally with `homey app run`. Thanks again!