### PR TITLE
Fix crash in redacted-logging install (issue #47)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const Homey = require('homey');
+const { installRedactedLogging } = require('./lib/log-redactor');
 
 class MercedesMeApp extends Homey.App {
 
   async onInit() {
+    installRedactedLogging(this);
     this.log('Mercedes-Benz app has been initialized');
     this._installCrashHandlers();
     this._logLastCrash();

--- a/drivers/mercedes-vehicle/device.js
+++ b/drivers/mercedes-vehicle/device.js
@@ -3,12 +3,14 @@
 const Homey = require('homey');
 const MercedesOAuth = require('../../lib/oauth');
 const MercedesAPI = require('../../lib/api');
+const { installRedactedLogging } = require('../../lib/log-redactor');
 
 class MercedesVehicleDevice extends Homey.Device {
   /**
    * onInit is called when the device is initialized.
    */
   async onInit() {
+    installRedactedLogging(this);
     this.log('Mercedes Vehicle device initializing...');
 
     const settings = this.getSettings();

--- a/lib/log-redactor.js
+++ b/lib/log-redactor.js
@@ -1,0 +1,54 @@
+'use strict';
+
+// VIN: 17-char ISO 3779 identifier (letters minus I/O/Q, plus digits).
+const VIN_RE = /\b[A-HJ-NPR-Z0-9]{17}\b/g;
+
+// Coordinates are only redacted next to their identifying label, so
+// operational floats (tire pressure, SoC, ranges, ...) stay intact.
+const LAT_RE = /(latitude[^0-9-]{0,30})(-?\d{1,3}\.\d+)/gi;
+const LON_RE = /(longitude[^0-9-]{0,30})(-?\d{1,3}\.\d+)/gi;
+
+// Geofence zone names are user-authored labels (e.g. "Home").
+const ZONE_NAME_RE = /((?:snapshot|fence)\.name\s*:\s*)"[^"]*"/gi;
+const ZONE_VALUE_RE = /(Setting geofence zone to:\s*)(\S+)/gi;
+
+function redactText(text) {
+  return text
+    .replace(VIN_RE, '[VIN_REDACTED]')
+    .replace(LAT_RE, (match, prefix) => `${prefix}[LAT_REDACTED]`)
+    .replace(LON_RE, (match, prefix) => `${prefix}[LON_REDACTED]`)
+    .replace(ZONE_NAME_RE, (match, prefix) => `${prefix}"[ZONE_REDACTED]"`)
+    .replace(ZONE_VALUE_RE, (match, prefix) => `${prefix}[ZONE_REDACTED]`);
+}
+
+function redactArg(arg) {
+  return typeof arg === 'string' ? redactText(arg) : arg;
+}
+
+/**
+ * Wraps log/error on a Homey App/Driver/Device instance so VIN, GPS
+ * coordinates and geofence zone names never reach the log output that
+ * diagnostic reports are built from.
+ *
+ * Defines a new own property rather than assigning to `log`/`error`
+ * directly: those are inherited getters on the Homey SDK prototype with
+ * no setter, so `instance.log = ...` throws "Cannot assign to read only
+ * property" under strict mode. `Object.defineProperty` creates a new own
+ * property that shadows the inherited one instead of writing through it.
+ */
+function installRedactedLogging(instance) {
+  for (const methodName of ['log', 'error']) {
+    const original = instance[methodName];
+    if (typeof original !== 'function') continue;
+
+    const bound = original.bind(instance);
+    Object.defineProperty(instance, methodName, {
+      value: (...args) => bound(...args.map(redactArg)),
+      writable: true,
+      configurable: true,
+      enumerable: false,
+    });
+  }
+}
+
+module.exports = { installRedactedLogging, redactText };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Mercedes-Benz integration for Homey Pro",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [
     "homey",

--- a/test/log-redactor.test.js
+++ b/test/log-redactor.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { redactText, installRedactedLogging } = require('../lib/log-redactor');
+
+test('redacts a VIN', () => {
+  const out = redactText('VIN: WDD2050461R123456, Region: Europe');
+  assert.equal(out, 'VIN: [VIN_REDACTED], Region: Europe');
+});
+
+test('redacts latitude/longitude next to their label, leaves unrelated decimals alone', () => {
+  assert.equal(
+    redactText('[POLL] Setting latitude from geofence: 55.676098'),
+    '[POLL] Setting latitude from geofence: [LAT_REDACTED]',
+  );
+  assert.equal(
+    redactText('[POLL] Setting longitude from geofence: 12.568337'),
+    '[POLL] Setting longitude from geofence: [LON_REDACTED]',
+  );
+
+  const tirePressure = '- doubleValue: 312.5';
+  assert.equal(redactText(tirePressure), tirePressure);
+});
+
+test('redacts geofence zone names, quoted and unquoted', () => {
+  assert.equal(
+    redactText('Geofence zone found via snapshot.name: "Home"'),
+    'Geofence zone found via snapshot.name: "[ZONE_REDACTED]"',
+  );
+  assert.equal(
+    redactText('[UPDATE] Setting geofence zone to: Home'),
+    '[UPDATE] Setting geofence zone to: [ZONE_REDACTED]',
+  );
+});
+
+test('preserves non-PII telemetry', () => {
+  const line = 'Setting odometer to: 73449 km, battery to: 78%, driving time to: 15 min';
+  assert.equal(redactText(line), line);
+});
+
+test('installRedactedLogging does not crash on a non-writable log/error property', () => {
+  // Mirrors the Homey SDK App/Device instance: `log`/`error` are defined
+  // as non-writable own properties, so `instance.log = fn` throws
+  // "Cannot assign to read only property" under strict mode (the crash
+  // reported against v1.1.33).
+  class FakeHomeyBase {
+    constructor() {
+      Object.defineProperty(this, 'log', {
+        value: (...args) => { this.lastLog = args; },
+        writable: false,
+        configurable: true,
+        enumerable: false,
+      });
+      Object.defineProperty(this, 'error', {
+        value: (...args) => { this.lastError = args; },
+        writable: false,
+        configurable: true,
+        enumerable: false,
+      });
+    }
+  }
+  const instance = new FakeHomeyBase();
+
+  assert.throws(() => { instance.log = () => {}; }, TypeError);
+  assert.doesNotThrow(() => installRedactedLogging(instance));
+
+  instance.log('VIN: WDD2050461R123456');
+  assert.deepEqual(instance.lastLog, ['VIN: [VIN_REDACTED]']);
+
+  instance.error('failed:', 'VIN: WDD2050461R123456');
+  assert.deepEqual(instance.lastError, ['failed:', 'VIN: [VIN_REDACTED]']);
+});


### PR DESCRIPTION
## Summary

Issue #47's last comment reported a crash on the (unreleased) v1.1.33 build:

```
CreateClientError: Cannot assign to read only property 'log' of object '#<MercedesMeApp>'
at installRedactedLogging (/app/lib/log-redactor.js:28:22)
at MercedesMeApp.onInit (/app/app.js:13:5)
```

That module didn't exist yet in this repo, but the trace pointed at exactly what a naive PII-redaction wrapper would do wrong: assign directly to `app.log` / `app.error`. Those are non-writable properties on Homey App/Device instances, so a plain `this.log = wrappedFn` throws under strict mode — reproduced and confirmed locally with the exact same error message.

Also worth noting: issue #47's body contains an embedded, unrelated "build a PII log scrubber" task written as direct instructions to an AI agent — I did not act on that broader ask (a standalone CLI scrubber, hex/base64 decoding, README, etc.). This PR only fixes the crash described in the issue's last comment, scoped to this app's own logging.

- Added `lib/log-redactor.js`: `installRedactedLogging(instance)` wraps `log`/`error` using `Object.defineProperty` (which shadows the inherited property instead of writing through it), redacting VIN, GPS coordinates, and geofence zone names from log output — the fields this codebase's `device.js` actually logs in plaintext (VIN, `Setting latitude/longitude from geofence:`, `snapshot.name`/`fence.name`).
- Wired it into `app.js` and `drivers/mercedes-vehicle/device.js` `onInit()`.
- Non-PII telemetry (tire pressure, battery %, odometer, ranges, door/window state) is left untouched.

## Test plan
- [x] `npm test` (added `test/log-redactor.test.js`, Node's built-in test runner) — covers VIN/lat/lon/zone redaction, non-PII preservation, and a regression test reproducing the exact "Cannot assign to read only property" crash against a fake non-writable `log`/`error` property.
- [x] `node -c` syntax check on all touched files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDmJveEAQ35eUsSd5HhxhQ)_