### PR TITLE
Fix silent capability-update abort and remaining PII/credential leaks (issue #47)

### DIFF
--- a/drivers/mercedes-vehicle/device.js
+++ b/drivers/mercedes-vehicle/device.js
@@ -631,398 +631,480 @@ class MercedesVehicleDevice extends Homey.Device {
       this.log('[UPDATE] Updating capabilities from vehicle data...');
 
       // Door lock status
-      if (data.doorlockstatusvehicle !== undefined) {
-        this.log(`[UPDATE] Door lock status raw value: ${data.doorlockstatusvehicle}`);
-        const locked = data.doorlockstatusvehicle === 2; // 2 = external locked
-        this.log(`[UPDATE] Setting locked to: ${locked}`);
-        if (this.getCapabilityValue('locked') !== locked) {
-          await this.setCapabilityValue('locked', locked);
+      try {
+        if (data.doorlockstatusvehicle !== undefined) {
+          this.log(`[UPDATE] Door lock status raw value: ${data.doorlockstatusvehicle}`);
+          const locked = data.doorlockstatusvehicle === 2; // 2 = external locked
+          this.log(`[UPDATE] Setting locked to: ${locked}`);
+          if (this.getCapabilityValue('locked') !== locked) {
+            await this.setCapabilityValue('locked', locked);
 
-          // Trigger flow cards
-          if (locked) {
-            await this.homey.flow.getDeviceTriggerCard('vehicle_locked').trigger(this);
-          } else {
-            await this.homey.flow.getDeviceTriggerCard('vehicle_unlocked').trigger(this);
+            // Trigger flow cards
+            if (locked) {
+              await this.homey.flow.getDeviceTriggerCard('vehicle_locked').trigger(this);
+            } else {
+              await this.homey.flow.getDeviceTriggerCard('vehicle_unlocked').trigger(this);
+            }
           }
+        } else {
+          this.log('[UPDATE] WARNING: doorlockstatusvehicle is undefined');
         }
-      } else {
-        this.log('[UPDATE] WARNING: doorlockstatusvehicle is undefined');
+      } catch (e) {
+        this.error('[UPDATE] Error updating door lock status:', e.message);
       }
 
       // Battery state of charge
-      if (data.soc !== undefined) {
-        const battery = parseInt(data.soc);
-        this.log(`[UPDATE] Setting battery to: ${battery}%`);
-        await this.setCapabilityValue('measure_battery', battery);
+      try {
+        if (data.soc !== undefined) {
+          const battery = parseInt(data.soc);
+          this.log(`[UPDATE] Setting battery to: ${battery}%`);
+          await this.setCapabilityValue('measure_battery', battery);
 
-        // Trigger low battery warning
-        if (battery < 20 && this.getCapabilityValue('measure_battery') >= 20) {
-          await this.homey.flow.getDeviceTriggerCard('low_battery')
-            .trigger(this, { battery_level: battery });
+          // Trigger low battery warning
+          if (battery < 20 && this.getCapabilityValue('measure_battery') >= 20) {
+            await this.homey.flow.getDeviceTriggerCard('low_battery')
+              .trigger(this, { battery_level: battery });
+          }
         }
+      } catch (e) {
+        this.error('[UPDATE] Error updating battery:', e.message);
       }
 
       // Charging power (kW) - check both lowercase and camelCase variants
-      const chargingPowerValue = data.chargingpower ?? data.chargingPower;
-      if (chargingPowerValue !== undefined) {
-        const chargingPower = parseFloat(chargingPowerValue);
-        const wasCharging = this.getCapabilityValue('measure_charge_power') > 0;
-        const isCharging = chargingPower > 0;
+      try {
+        const chargingPowerValue = data.chargingpower ?? data.chargingPower;
+        if (chargingPowerValue !== undefined) {
+          const chargingPower = parseFloat(chargingPowerValue);
+          const wasCharging = this.getCapabilityValue('measure_charge_power') > 0;
+          const isCharging = chargingPower > 0;
 
-        await this.setCapabilityValue('measure_charge_power', chargingPower);
+          await this.setCapabilityValue('measure_charge_power', chargingPower);
 
-        // Update charging on/off capability
-        if (this.hasCapability('onoff_charging')) {
-          await this.setCapabilityValue('onoff_charging', isCharging);
+          // Update charging on/off capability
+          if (this.hasCapability('onoff_charging')) {
+            await this.setCapabilityValue('onoff_charging', isCharging);
+          }
+
+          // Trigger charging flow cards
+          if (!wasCharging && isCharging) {
+            await this.homey.flow.getDeviceTriggerCard('charging_started')
+              .trigger(this, { charging_power: chargingPower });
+            this.log(`[TRIGGER] Charging started with ${chargingPower} kW`);
+          } else if (wasCharging && !isCharging) {
+            await this.homey.flow.getDeviceTriggerCard('charging_stopped').trigger(this);
+            this.log('[TRIGGER] Charging stopped');
+          }
         }
-
-        // Trigger charging flow cards
-        if (!wasCharging && isCharging) {
-          await this.homey.flow.getDeviceTriggerCard('charging_started')
-            .trigger(this, { charging_power: chargingPower });
-          this.log(`[TRIGGER] Charging started with ${chargingPower} kW`);
-        } else if (wasCharging && !isCharging) {
-          await this.homey.flow.getDeviceTriggerCard('charging_stopped').trigger(this);
-          this.log('[TRIGGER] Charging stopped');
-        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating charging power:', e.message);
       }
 
       // Engine state — Mercedes sends `enginestate` for ICE cars; EVs don't
       // include that key, so fall back to `ignitionstate` (4 = engine on / ready).
-      const engineStateValue = data.enginestate ?? data.engineState;
-      const ignitionValue = data.ignitionstate;
-      let engineRunning = null;
-      let engineSource = null;
+      try {
+        const engineStateValue = data.enginestate ?? data.engineState;
+        const ignitionValue = data.ignitionstate;
+        let engineRunning = null;
+        let engineSource = null;
 
-      if (engineStateValue !== undefined) {
-        engineSource = 'enginestate';
-        if (typeof engineStateValue === 'boolean') {
-          engineRunning = engineStateValue;
-        } else if (typeof engineStateValue === 'string') {
-          const s = engineStateValue.toUpperCase();
-          engineRunning = s === 'RUNNING' || s === 'ON' || s === '1' || s === 'TRUE';
-        } else {
-          engineRunning = Number(engineStateValue) === 1;
+        if (engineStateValue !== undefined) {
+          engineSource = 'enginestate';
+          if (typeof engineStateValue === 'boolean') {
+            engineRunning = engineStateValue;
+          } else if (typeof engineStateValue === 'string') {
+            const s = engineStateValue.toUpperCase();
+            engineRunning = s === 'RUNNING' || s === 'ON' || s === '1' || s === 'TRUE';
+          } else {
+            engineRunning = Number(engineStateValue) === 1;
+          }
+        } else if (ignitionValue !== undefined) {
+          engineSource = 'ignitionstate';
+          engineRunning = Number(ignitionValue) === 4; // 4 = start (engine/EV ready to drive)
         }
-      } else if (ignitionValue !== undefined) {
-        engineSource = 'ignitionstate';
-        engineRunning = Number(ignitionValue) === 4; // 4 = start (engine/EV ready to drive)
-      }
 
-      if (engineRunning !== null) {
-        const wasRunning = this.getCapabilityValue('engine_running');
-        this.log(`[UPDATE] Engine state from ${engineSource}=${engineSource === 'enginestate' ? engineStateValue : ignitionValue} -> running=${engineRunning}, was=${wasRunning}`);
+        if (engineRunning !== null) {
+          const wasRunning = this.getCapabilityValue('engine_running');
+          this.log(`[UPDATE] Engine state from ${engineSource}=${engineSource === 'enginestate' ? engineStateValue : ignitionValue} -> running=${engineRunning}, was=${wasRunning}`);
 
-        if (wasRunning !== engineRunning) {
-          await this.setCapabilityValue('engine_running', engineRunning);
+          if (wasRunning !== engineRunning) {
+            await this.setCapabilityValue('engine_running', engineRunning);
 
-          // Skip triggers on initial read (capability was null/unset before)
-          if (wasRunning !== null && wasRunning !== undefined) {
-            if (engineRunning) {
-              this.log('[TRIGGER] Firing engine_started');
-              await this.homey.flow.getDeviceTriggerCard('engine_started').trigger(this);
-            } else {
-              this.log('[TRIGGER] Firing engine_stopped');
-              await this.homey.flow.getDeviceTriggerCard('engine_stopped').trigger(this);
+            // Skip triggers on initial read (capability was null/unset before)
+            if (wasRunning !== null && wasRunning !== undefined) {
+              if (engineRunning) {
+                this.log('[TRIGGER] Firing engine_started');
+                await this.homey.flow.getDeviceTriggerCard('engine_started').trigger(this);
+              } else {
+                this.log('[TRIGGER] Firing engine_stopped');
+                await this.homey.flow.getDeviceTriggerCard('engine_stopped').trigger(this);
+              }
             }
           }
         }
+      } catch (e) {
+        this.error('[UPDATE] Error updating engine state:', e.message);
       }
 
       // Climate control status
-      if (data.precondActive !== undefined) {
-        await this.setCapabilityValue('climate_active', data.precondActive === true);
+      try {
+        if (data.precondActive !== undefined) {
+          await this.setCapabilityValue('climate_active', data.precondActive === true);
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating climate control status:', e.message);
       }
 
       // Tire pressures (already converted from kPa to bar in parser)
       // Check both lowercase and camelCase variants for API compatibility
-      const tirePressureFL = data.tirepressurefrontleft ?? data.tirepressureFrontLeft;
-      if (tirePressureFL !== undefined) {
-        await this.setCapabilityValue('tire_pressure_bar.tire_fl', parseFloat(tirePressureFL));
-      }
-      const tirePressureFR = data.tirepressurefrontright ?? data.tirepressureFrontRight;
-      if (tirePressureFR !== undefined) {
-        await this.setCapabilityValue('tire_pressure_bar.tire_fr', parseFloat(tirePressureFR));
-      }
-      const tirePressureRL = data.tirepressurerearleft ?? data.tirepressureRearLeft;
-      if (tirePressureRL !== undefined) {
-        await this.setCapabilityValue('tire_pressure_bar.tire_rl', parseFloat(tirePressureRL));
-      }
-      const tirePressureRR = data.tirepressurerearright ?? data.tirepressureRearRight;
-      if (tirePressureRR !== undefined) {
-        await this.setCapabilityValue('tire_pressure_bar.tire_rr', parseFloat(tirePressureRR));
+      try {
+        const tirePressureFL = data.tirepressurefrontleft ?? data.tirepressureFrontLeft;
+        if (tirePressureFL !== undefined) {
+          await this.setCapabilityValue('tire_pressure_bar.tire_fl', parseFloat(tirePressureFL));
+        }
+        const tirePressureFR = data.tirepressurefrontright ?? data.tirepressureFrontRight;
+        if (tirePressureFR !== undefined) {
+          await this.setCapabilityValue('tire_pressure_bar.tire_fr', parseFloat(tirePressureFR));
+        }
+        const tirePressureRL = data.tirepressurerearleft ?? data.tirepressureRearLeft;
+        if (tirePressureRL !== undefined) {
+          await this.setCapabilityValue('tire_pressure_bar.tire_rl', parseFloat(tirePressureRL));
+        }
+        const tirePressureRR = data.tirepressurerearright ?? data.tirepressureRearRight;
+        if (tirePressureRR !== undefined) {
+          await this.setCapabilityValue('tire_pressure_bar.tire_rr', parseFloat(tirePressureRR));
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating tire pressures:', e.message);
       }
 
       // Odometer reading
-      if (data.odo !== undefined) {
-        this.log(`[UPDATE] Setting odometer to: ${data.odo} km`);
-        await this.setCapabilityValue('odometer', parseFloat(data.odo));
+      try {
+        if (data.odo !== undefined) {
+          this.log(`[UPDATE] Setting odometer to: ${data.odo} km`);
+          await this.setCapabilityValue('odometer', parseFloat(data.odo));
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating odometer:', e.message);
       }
 
-      // Trip distance since start - check both lowercase and camelCase variants
-      const distanceStartValue = data.distancestart ?? data.distanceStart;
-      if (distanceStartValue !== undefined) {
-        this.log(`[UPDATE] Setting trip distance to: ${distanceStartValue} km`);
-        await this.setCapabilityValue('distance_start', parseFloat(distanceStartValue));
-      }
+      // Trip distance / electric distance / driving time since start
+      try {
+        const distanceStartValue = data.distancestart ?? data.distanceStart;
+        if (distanceStartValue !== undefined) {
+          this.log(`[UPDATE] Setting trip distance to: ${distanceStartValue} km`);
+          await this.setCapabilityValue('distance_start', parseFloat(distanceStartValue));
+        }
 
-      // Electric trip distance - check both lowercase and camelCase variants
-      const distanceElectricalValue = data.distanceelectricalstart ?? data.distanceElectricalStart;
-      if (distanceElectricalValue !== undefined) {
-        this.log(`[UPDATE] Setting electric distance to: ${distanceElectricalValue} km`);
-        await this.setCapabilityValue('distance_electrical', parseFloat(distanceElectricalValue));
-      }
+        const distanceElectricalValue = data.distanceelectricalstart ?? data.distanceElectricalStart;
+        if (distanceElectricalValue !== undefined) {
+          this.log(`[UPDATE] Setting electric distance to: ${distanceElectricalValue} km`);
+          await this.setCapabilityValue('distance_electrical', parseFloat(distanceElectricalValue));
+        }
 
-      // Driving time since start - check both lowercase and camelCase variants
-      const drivenTimeValue = data.driventimestart ?? data.drivenTimeStart;
-      if (drivenTimeValue !== undefined) {
-        this.log(`[UPDATE] Setting driving time to: ${drivenTimeValue} min`);
-        await this.setCapabilityValue('driven_time_start', parseInt(drivenTimeValue));
+        const drivenTimeValue = data.driventimestart ?? data.drivenTimeStart;
+        if (drivenTimeValue !== undefined) {
+          this.log(`[UPDATE] Setting driving time to: ${drivenTimeValue} min`);
+          await this.setCapabilityValue('driven_time_start', parseInt(drivenTimeValue));
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating trip distance/time:', e.message);
       }
 
       // Average speed since start - check both lowercase and camelCase variants
-      const averageSpeedValue = data.averagespeedstart ?? data.averageSpeedStart;
-      if (averageSpeedValue !== undefined) {
-        const speed = parseFloat(averageSpeedValue);
-        this.log(`[UPDATE] Setting average speed to: ${speed} km/h`);
-        await this.setCapabilityValue('average_speed', speed);
-      } else {
-        // Set to 0 when not available (car is stopped)
-        await this.setCapabilityValue('average_speed', 0);
+      try {
+        const averageSpeedValue = data.averagespeedstart ?? data.averageSpeedStart;
+        if (averageSpeedValue !== undefined) {
+          const speed = parseFloat(averageSpeedValue);
+          this.log(`[UPDATE] Setting average speed to: ${speed} km/h`);
+          await this.setCapabilityValue('average_speed', speed);
+        } else {
+          // Set to 0 when not available (car is stopped)
+          await this.setCapabilityValue('average_speed', 0);
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating average speed:', e.message);
       }
 
-      const ecoScoreAccel = data.ecoscoreaccel ?? data.ecoScoreAccel ?? data.ecoscoreAccel;
-      if (ecoScoreAccel !== undefined) {
-        this.log(`[UPDATE] Setting acceleration eco score to: ${ecoScoreAccel}`);
-        await this.setCapabilityValue('ecoscore_accel', parseInt(ecoScoreAccel));
-      }
-      const ecoScoreConst = data.ecoscoreconst ?? data.ecoScoreConst ?? data.ecoscoreConst;
-      if (ecoScoreConst !== undefined) {
-        this.log(`[UPDATE] Setting constant eco score to: ${ecoScoreConst}`);
-        await this.setCapabilityValue('ecoscore_const', parseInt(ecoScoreConst));
-      }
-      const ecoScoreFreeWhl = data.ecoscorefreewhl ?? data.ecoScoreFreeWhl ?? data.ecoscoreFreeWhl ?? data.ecoScoreFreewheel;
-      if (ecoScoreFreeWhl !== undefined) {
-        this.log(`[UPDATE] Setting freewheel eco score to: ${ecoScoreFreeWhl}`);
-        await this.setCapabilityValue('ecoscore_freewhl', parseInt(ecoScoreFreeWhl));
+      try {
+        const ecoScoreAccel = data.ecoscoreaccel ?? data.ecoScoreAccel ?? data.ecoscoreAccel;
+        if (ecoScoreAccel !== undefined) {
+          this.log(`[UPDATE] Setting acceleration eco score to: ${ecoScoreAccel}`);
+          await this.setCapabilityValue('ecoscore_accel', parseInt(ecoScoreAccel));
+        }
+        const ecoScoreConst = data.ecoscoreconst ?? data.ecoScoreConst ?? data.ecoscoreConst;
+        if (ecoScoreConst !== undefined) {
+          this.log(`[UPDATE] Setting constant eco score to: ${ecoScoreConst}`);
+          await this.setCapabilityValue('ecoscore_const', parseInt(ecoScoreConst));
+        }
+        const ecoScoreFreeWhl = data.ecoscorefreewhl ?? data.ecoScoreFreeWhl ?? data.ecoscoreFreeWhl ?? data.ecoScoreFreewheel;
+        if (ecoScoreFreeWhl !== undefined) {
+          this.log(`[UPDATE] Setting freewheel eco score to: ${ecoScoreFreeWhl}`);
+          await this.setCapabilityValue('ecoscore_freewhl', parseInt(ecoScoreFreeWhl));
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating eco scores:', e.message);
       }
 
       // Generic alarm (warnings) with trigger
-      const hasWarning = data.warningwashwater || data.warningcoolantlevellow ||
-                        data.warningbrakefluid || data.warningenginelight;
-      const hadWarning = this.getCapabilityValue('alarm_generic');
-      await this.setCapabilityValue('alarm_generic', hasWarning === true);
+      try {
+        const hasWarning = data.warningwashwater || data.warningcoolantlevellow ||
+                          data.warningbrakefluid || data.warningenginelight;
+        const hadWarning = this.getCapabilityValue('alarm_generic');
+        await this.setCapabilityValue('alarm_generic', hasWarning === true);
 
-      // Trigger warning light activated when a new warning appears
-      if (hasWarning === true && hadWarning !== true) {
-        await this.homey.flow.getDeviceTriggerCard('warning_light_activated').trigger(this);
+        // Trigger warning light activated when a new warning appears
+        if (hasWarning === true && hadWarning !== true) {
+          await this.homey.flow.getDeviceTriggerCard('warning_light_activated').trigger(this);
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating generic alarm:', e.message);
       }
 
       // --- NEW CAPABILITIES ---
 
-      // Electric range
-      if (data.rangeelectric !== undefined) {
-        this.log(`[UPDATE] Setting electric range to: ${data.rangeelectric} km`);
-        await this.setCapabilityValue('measure_range_electric', parseFloat(data.rangeelectric));
-      }
+      // Electric range / liquid fuel range / fuel level / AdBlue level
+      try {
+        if (data.rangeelectric !== undefined) {
+          this.log(`[UPDATE] Setting electric range to: ${data.rangeelectric} km`);
+          await this.setCapabilityValue('measure_range_electric', parseFloat(data.rangeelectric));
+        }
 
-      // Liquid fuel range
-      if (data.rangeliquid !== undefined) {
-        this.log(`[UPDATE] Setting liquid range to: ${data.rangeliquid} km`);
-        await this.setCapabilityValue('measure_range_liquid', parseFloat(data.rangeliquid));
-      }
+        if (data.rangeliquid !== undefined) {
+          this.log(`[UPDATE] Setting liquid range to: ${data.rangeliquid} km`);
+          await this.setCapabilityValue('measure_range_liquid', parseFloat(data.rangeliquid));
+        }
 
-      // Fuel level
-      if (data.tanklevelpercent !== undefined) {
-        this.log(`[UPDATE] Setting fuel level to: ${data.tanklevelpercent}%`);
-        await this.setCapabilityValue('measure_fuel', parseInt(data.tanklevelpercent));
-      }
+        if (data.tanklevelpercent !== undefined) {
+          this.log(`[UPDATE] Setting fuel level to: ${data.tanklevelpercent}%`);
+          await this.setCapabilityValue('measure_fuel', parseInt(data.tanklevelpercent));
+        }
 
-      // AdBlue level
-      if (data.tankLevelAdBlue !== undefined) {
-        this.log(`[UPDATE] Setting AdBlue level to: ${data.tankLevelAdBlue}%`);
-        await this.setCapabilityValue('measure_adblue_level', parseInt(data.tankLevelAdBlue));
+        if (data.tankLevelAdBlue !== undefined) {
+          this.log(`[UPDATE] Setting AdBlue level to: ${data.tankLevelAdBlue}%`);
+          await this.setCapabilityValue('measure_adblue_level', parseInt(data.tankLevelAdBlue));
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating range/fuel levels:', e.message);
       }
-
 
       // Ignition state
-      if (data.ignitionstate !== undefined) {
-        const raw = Number(data.ignitionstate);
-        const ignitionOn = raw === 1 || raw === 2 || raw === 4; // 0: lock/off, 1: radio, 2: ignition, 4: start
-        this.log(`[UPDATE] Setting ignition state to: ${ignitionOn} (raw: ${data.ignitionstate})`);
-        await this.setCapabilityValue('ignition_on', ignitionOn);
+      try {
+        if (data.ignitionstate !== undefined) {
+          const raw = Number(data.ignitionstate);
+          const ignitionOn = raw === 1 || raw === 2 || raw === 4; // 0: lock/off, 1: radio, 2: ignition, 4: start
+          this.log(`[UPDATE] Setting ignition state to: ${ignitionOn} (raw: ${data.ignitionstate})`);
+          await this.setCapabilityValue('ignition_on', ignitionOn);
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating ignition state:', e.message);
       }
 
       // Oil level (percent)
-      if (data.oilLevel !== undefined) {
-        this.log(`[UPDATE] Setting oil level to: ${data.oilLevel}%`);
-        await this.setCapabilityValue('measure_oil_level', parseInt(data.oilLevel));
+      try {
+        if (data.oilLevel !== undefined) {
+          this.log(`[UPDATE] Setting oil level to: ${data.oilLevel}%`);
+          await this.setCapabilityValue('measure_oil_level', parseInt(data.oilLevel));
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating oil level:', e.message);
       }
 
       // Charging status (text) with charging completed trigger
-      if (data.chargingstatus !== undefined) {
-        const oldStatus = this.getCapabilityValue('text_charging_status');
-        // Translate Mercedes charging status codes to readable text
-        const statusMap = {
-          '0': 'Charging',
-          '1': 'Charging ends',
-          '2': 'Charge break',
-          '3': 'Unplugged',
-          '4': 'Failure',
-          '5': 'Slow charging',
-          '6': 'Fast charging',
-          '7': 'Discharging',
-          '8': 'Not charging',
-          '9': 'Slow charging (after trip target)',
-          '10': 'Charging (after trip target)',
-          '11': 'Fast charging (after trip target)',
-          '12': 'Connected',
-          '13': 'AC charging',
-          '14': 'DC charging',
-          '15': 'Battery calibration active',
-          '16': 'Unknown',
-        };
-        const rawStatus = String(data.chargingstatus);
-        const readableStatus = statusMap[rawStatus] || rawStatus;
-        this.log(`[UPDATE] Setting charging status to: ${rawStatus} (${readableStatus})`);
-        await this.setCapabilityValue('text_charging_status', readableStatus);
+      try {
+        if (data.chargingstatus !== undefined) {
+          const oldStatus = this.getCapabilityValue('text_charging_status');
+          // Translate Mercedes charging status codes to readable text
+          const statusMap = {
+            '0': 'Charging',
+            '1': 'Charging ends',
+            '2': 'Charge break',
+            '3': 'Unplugged',
+            '4': 'Failure',
+            '5': 'Slow charging',
+            '6': 'Fast charging',
+            '7': 'Discharging',
+            '8': 'Not charging',
+            '9': 'Slow charging (after trip target)',
+            '10': 'Charging (after trip target)',
+            '11': 'Fast charging (after trip target)',
+            '12': 'Connected',
+            '13': 'AC charging',
+            '14': 'DC charging',
+            '15': 'Battery calibration active',
+            '16': 'Unknown',
+          };
+          const rawStatus = String(data.chargingstatus);
+          const readableStatus = statusMap[rawStatus] || rawStatus;
+          this.log(`[UPDATE] Setting charging status to: ${rawStatus} (${readableStatus})`);
+          await this.setCapabilityValue('text_charging_status', readableStatus);
 
-        // Trigger charging completed when status changes to "charging ends" (1)
-        const completedStatuses = ['CHARGING ENDS', 'FINISHED', 'COMPLETED', 'END'];
-        const wasCharging = oldStatus && !completedStatuses.includes(String(oldStatus).toUpperCase());
-        const isCompleted = rawStatus === '1' || completedStatuses.includes(readableStatus.toUpperCase());
+          // Trigger charging completed when status changes to "charging ends" (1)
+          const completedStatuses = ['CHARGING ENDS', 'FINISHED', 'COMPLETED', 'END'];
+          const wasCharging = oldStatus && !completedStatuses.includes(String(oldStatus).toUpperCase());
+          const isCompleted = rawStatus === '1' || completedStatuses.includes(readableStatus.toUpperCase());
 
-        if (wasCharging && isCompleted) {
-          const batteryLevel = this.getCapabilityValue('measure_battery') || 0;
-          await this.homey.flow.getDeviceTriggerCard('charging_completed')
-            .trigger(this, { battery_level: batteryLevel });
+          if (wasCharging && isCompleted) {
+            const batteryLevel = this.getCapabilityValue('measure_battery') || 0;
+            await this.homey.flow.getDeviceTriggerCard('charging_completed')
+              .trigger(this, { battery_level: batteryLevel });
+          }
         }
+      } catch (e) {
+        this.error('[UPDATE] Error updating charging status:', e.message);
       }
 
       // Charge coupler / connector status with plugged in/unplugged triggers
-      const couplerValue = data.chargeCouplerACStatus ?? data.chargecoupleracstatus
-        ?? data.chargeCouplerDCStatus ?? data.chargecoupledcstatus;
-      if (couplerValue === null) {
-        await this.setCapabilityValue('text_connector_status', 'Unknown');
-      } else if (couplerValue !== undefined) {
-        const statusMap = {
-          '0': 'Connected (locked)',
-          '1': 'Connected (unlocked)',
-          '2': 'Disconnected',
-          '3': 'Error',
-          '4': 'Charging started',
-        };
-        const rawStatus = String(couplerValue);
-        const readableStatus = statusMap[rawStatus] || rawStatus;
-        const oldStatus = this.getCapabilityValue('text_connector_status');
-        this.log(`[UPDATE] Setting connector status to: ${rawStatus} (${readableStatus})`);
-        await this.setCapabilityValue('text_connector_status', readableStatus);
-        await this.setCapabilityValue('onoff_connector', readableStatus !== 'Disconnected');
+      try {
+        const couplerValue = data.chargeCouplerACStatus ?? data.chargecoupleracstatus
+          ?? data.chargeCouplerDCStatus ?? data.chargecoupledcstatus;
+        if (couplerValue === null) {
+          await this.setCapabilityValue('text_connector_status', 'Unknown');
+        } else if (couplerValue !== undefined) {
+          const statusMap = {
+            '0': 'Connected (locked)',
+            '1': 'Connected (unlocked)',
+            '2': 'Disconnected',
+            '3': 'Error',
+            '4': 'Charging started',
+          };
+          const rawStatus = String(couplerValue);
+          const readableStatus = statusMap[rawStatus] || rawStatus;
+          const oldStatus = this.getCapabilityValue('text_connector_status');
+          this.log(`[UPDATE] Setting connector status to: ${rawStatus} (${readableStatus})`);
+          await this.setCapabilityValue('text_connector_status', readableStatus);
+          await this.setCapabilityValue('onoff_connector', readableStatus !== 'Disconnected');
 
-        // Determine connected state (anything that is not 'Disconnected')
-        const isConnected = readableStatus !== 'Disconnected';
-        const wasConnected = oldStatus !== null && oldStatus !== 'Disconnected';
+          // Determine connected state (anything that is not 'Disconnected')
+          const isConnected = readableStatus !== 'Disconnected';
+          const wasConnected = oldStatus !== null && oldStatus !== 'Disconnected';
 
-        if (!wasConnected && isConnected) {
-          await this.homey.flow.getDeviceTriggerCard('connector_connected').trigger(this);
-          this.log('[TRIGGER] Charger connected');
-        } else if (wasConnected && !isConnected) {
-          await this.homey.flow.getDeviceTriggerCard('connector_disconnected').trigger(this);
-          this.log('[TRIGGER] Charger disconnected');
+          if (!wasConnected && isConnected) {
+            await this.homey.flow.getDeviceTriggerCard('connector_connected').trigger(this);
+            this.log('[TRIGGER] Charger connected');
+          } else if (wasConnected && !isConnected) {
+            await this.homey.flow.getDeviceTriggerCard('connector_disconnected').trigger(this);
+            this.log('[TRIGGER] Charger disconnected');
+          }
         }
+      } catch (e) {
+        this.error('[UPDATE] Error updating connector status:', e.message);
       }
 
       // Selected charge program (text)
-      if (data.selectedChargeProgram !== undefined) {
-        const programMap = {
-          '0': 'Default',
-          '2': 'Home',
-          '3': 'Work',
-        };
-        const rawProgram = String(data.selectedChargeProgram);
-        const readableProgram = programMap[rawProgram] || rawProgram;
-        this.log(`[UPDATE] Setting selected charge program to: ${rawProgram} (${readableProgram})`);
-        await this.setCapabilityValue('text_charge_program', readableProgram);
-        await this.setStoreValue('selectedChargeProgramRaw', data.selectedChargeProgram);
+      try {
+        if (data.selectedChargeProgram !== undefined) {
+          const programMap = {
+            '0': 'Default',
+            '2': 'Home',
+            '3': 'Work',
+          };
+          const rawProgram = String(data.selectedChargeProgram);
+          const readableProgram = programMap[rawProgram] || rawProgram;
+          this.log(`[UPDATE] Setting selected charge program to: ${rawProgram} (${readableProgram})`);
+          await this.setCapabilityValue('text_charge_program', readableProgram);
+          await this.setStoreValue('selectedChargeProgramRaw', data.selectedChargeProgram);
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating selected charge program:', e.message);
       }
 
       // Max SoC (check both maxSoc and max_soc as API may use either)
-      const maxSocValue = data.maxSoc !== undefined ? data.maxSoc : data.max_soc;
-      if (maxSocValue !== undefined) {
-        this.log(`[UPDATE] Setting max SoC to: ${maxSocValue}%`);
-        await this.setCapabilityValue('measure_max_soc', parseInt(maxSocValue));
+      try {
+        const maxSocValue = data.maxSoc !== undefined ? data.maxSoc : data.max_soc;
+        if (maxSocValue !== undefined) {
+          this.log(`[UPDATE] Setting max SoC to: ${maxSocValue}%`);
+          await this.setCapabilityValue('measure_max_soc', parseInt(maxSocValue));
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating max SoC:', e.message);
       }
 
       // End of charge time — API sends minutes since midnight (e.g. 825 = 13:45)
-      if (data.endofchargetime !== undefined) {
-        const totalMinutes = parseInt(data.endofchargetime);
-        const hh = String(Math.floor(totalMinutes / 60)).padStart(2, '0');
-        const mm = String(totalMinutes % 60).padStart(2, '0');
-        const timeStr = `${hh}:${mm}`;
-        this.log(`[UPDATE] Setting end of charge time to: ${timeStr} (raw: ${data.endofchargetime})`);
-        await this.setCapabilityValue('text_end_charge_time', timeStr);
+      try {
+        if (data.endofchargetime !== undefined) {
+          const totalMinutes = parseInt(data.endofchargetime);
+          const hh = String(Math.floor(totalMinutes / 60)).padStart(2, '0');
+          const mm = String(totalMinutes % 60).padStart(2, '0');
+          const timeStr = `${hh}:${mm}`;
+          this.log(`[UPDATE] Setting end of charge time to: ${timeStr} (raw: ${data.endofchargetime})`);
+          await this.setCapabilityValue('text_end_charge_time', timeStr);
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating end of charge time:', e.message);
       }
 
       // Sunroof status (text)
-      if (data.sunroofstatus !== undefined) {
-        const sunroofMap = {
-          0: 'Closed',
-          1: 'Open',
-          2: 'Tilted',
-          3: 'Running',
-          4: 'Anti-Booming',
-          5: 'Intermediate',
-          6: 'Opening',
-          7: 'Closing'
-        };
-        const sunroofStatus = sunroofMap[data.sunroofstatus] || String(data.sunroofstatus);
-        this.log(`[UPDATE] Setting sunroof status to: ${sunroofStatus} (raw: ${data.sunroofstatus})`);
-        await this.setCapabilityValue('window_sunroof', sunroofStatus);
+      try {
+        if (data.sunroofstatus !== undefined) {
+          const sunroofMap = {
+            0: 'Closed',
+            1: 'Open',
+            2: 'Tilted',
+            3: 'Running',
+            4: 'Anti-Booming',
+            5: 'Intermediate',
+            6: 'Opening',
+            7: 'Closing'
+          };
+          const sunroofStatus = sunroofMap[data.sunroofstatus] || String(data.sunroofstatus);
+          this.log(`[UPDATE] Setting sunroof status to: ${sunroofStatus} (raw: ${data.sunroofstatus})`);
+          await this.setCapabilityValue('window_sunroof', sunroofStatus);
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating sunroof status:', e.message);
       }
 
-      // Departure Time (value is minutes from midnight, convert to HH:MM)
-      if (data.departuretime !== undefined) {
-        const minutes = Number(data.departuretime);
-        const hours = Math.floor(minutes / 60);
-        const mins = minutes % 60;
-        const departureTimeStr = `${String(hours).padStart(2, '0')}:${String(mins).padStart(2, '0')}`;
-        this.log(`[UPDATE] Setting departure time to: ${departureTimeStr} (raw: ${data.departuretime})`);
-        await this.setCapabilityValue('text_departure_time', departureTimeStr);
-      }
+      // Departure Time (value is minutes from midnight, convert to HH:MM) and mode
+      try {
+        if (data.departuretime !== undefined) {
+          const minutes = Number(data.departuretime);
+          const hours = Math.floor(minutes / 60);
+          const mins = minutes % 60;
+          const departureTimeStr = `${String(hours).padStart(2, '0')}:${String(mins).padStart(2, '0')}`;
+          this.log(`[UPDATE] Setting departure time to: ${departureTimeStr} (raw: ${data.departuretime})`);
+          await this.setCapabilityValue('text_departure_time', departureTimeStr);
+        }
 
-      // Departure Time Mode (check multiple possible field names)
-      const departureTimeModeRaw = data.departureTimeMode !== undefined ? data.departureTimeMode :
-                                   data.departuretimemode !== undefined ? data.departuretimemode :
-                                   data.departuretime_mode;
-      if (departureTimeModeRaw !== undefined) {
-        const departureModeMap = {
-          0: 'Inactive',
-          1: 'Single',
-          2: 'Weekly'
-        };
-        const departureTimeModeValue = departureModeMap[departureTimeModeRaw] || String(departureTimeModeRaw);
-        this.log(`[UPDATE] Setting departure time mode to: ${departureTimeModeValue} (raw: ${departureTimeModeRaw})`);
-        await this.setCapabilityValue('text_departure_time_mode', departureTimeModeValue);
+        // Departure Time Mode (check multiple possible field names)
+        const departureTimeModeRaw = data.departureTimeMode !== undefined ? data.departureTimeMode :
+                                     data.departuretimemode !== undefined ? data.departuretimemode :
+                                     data.departuretime_mode;
+        if (departureTimeModeRaw !== undefined) {
+          const departureModeMap = {
+            0: 'Inactive',
+            1: 'Single',
+            2: 'Weekly'
+          };
+          const departureTimeModeValue = departureModeMap[departureTimeModeRaw] || String(departureTimeModeRaw);
+          this.log(`[UPDATE] Setting departure time mode to: ${departureTimeModeValue} (raw: ${departureTimeModeRaw})`);
+          await this.setCapabilityValue('text_departure_time_mode', departureTimeModeValue);
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating departure time/mode:', e.message);
       }
 
       // Position latitude/longitude are NOT available in vehicle attributes API
       // They come from geofencing violations API (polled separately)
-      const posLat = data.positionlat ?? data.positionLat ?? data.latitude ?? data.gpsLat ?? data.gpslat;
-      const posLong = data.positionlong ?? data.positionLong ?? data.longitude ?? data.gpsLon ?? data.gpslon;
-      if (posLat !== undefined && posLong !== undefined) {
-        const lat = parseFloat(posLat);
-        const long = parseFloat(posLong);
-        this.log(`[UPDATE] Setting location: ${lat}, ${long}`);
-        await this.setCapabilityValue('measure_latitude', lat);
-        await this.setCapabilityValue('measure_longitude', long);
-      }
+      try {
+        const posLat = data.positionlat ?? data.positionLat ?? data.latitude ?? data.gpsLat ?? data.gpslat;
+        const posLong = data.positionlong ?? data.positionLong ?? data.longitude ?? data.gpsLon ?? data.gpslon;
+        if (posLat !== undefined && posLong !== undefined) {
+          const lat = parseFloat(posLat);
+          const long = parseFloat(posLong);
+          this.log(`[UPDATE] Setting location - latitude: ${lat}, longitude: ${long}`);
+          await this.setCapabilityValue('measure_latitude', lat);
+          await this.setCapabilityValue('measure_longitude', long);
+        }
 
-      // Heading - the correct field name is positionHeading (camelCase)
-      const posHeading = data.positionHeading ?? data.positionheading ?? data.heading ?? data.gpsHeading ?? data.gpsheading;
-      if (posHeading !== undefined) {
-        const heading = parseFloat(posHeading);
-        this.log(`[UPDATE] Setting heading: ${heading}`);
-        await this.setCapabilityValue('measure_heading', heading);
+        // Heading - the correct field name is positionHeading (camelCase)
+        const posHeading = data.positionHeading ?? data.positionheading ?? data.heading ?? data.gpsHeading ?? data.gpsheading;
+        if (posHeading !== undefined) {
+          const heading = parseFloat(posHeading);
+          this.log(`[UPDATE] Setting heading: ${heading}`);
+          await this.setCapabilityValue('measure_heading', heading);
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating position/heading:', e.message);
       }
 
       // Window statuses with flow triggers
@@ -1109,100 +1191,117 @@ class MercedesVehicleDevice extends Homey.Device {
         }
       }
 
-      // Parking brake status
-      if (data.parkbrakestatus !== undefined) {
-        const parkBrakeEngaged = data.parkbrakestatus === true || data.parkbrakestatus === 'true' || data.parkbrakestatus === 1;
-        await this.setCapabilityValue('parking_brake_engaged', parkBrakeEngaged);
-      }
+      // Parking brake status / service interval days
+      try {
+        if (data.parkbrakestatus !== undefined) {
+          const parkBrakeEngaged = data.parkbrakestatus === true || data.parkbrakestatus === 'true' || data.parkbrakestatus === 1;
+          await this.setCapabilityValue('parking_brake_engaged', parkBrakeEngaged);
+        }
 
-      // Service interval days
-      if (data.serviceintervaldays !== undefined) {
-        await this.setCapabilityValue('measure_service_days', parseInt(data.serviceintervaldays));
+        if (data.serviceintervaldays !== undefined) {
+          await this.setCapabilityValue('measure_service_days', parseInt(data.serviceintervaldays));
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating parking brake/service interval:', e.message);
       }
 
       // Battery temperature (EV) - check various possible attribute names
       // Mercedes uses different naming conventions: temperaturehvbattery, hvbatterytemperature, etc.
-      const batteryTempValue = data.temperaturehvbattery ?? data.temperatureHVBattery ??
-        data.hvbatterytemperature ?? data.hvBatteryTemperature ??
-        data.ecoelectricbatterytemperature ?? data.ecoElectricBatteryTemperature ??
-        data.batterytemperature ?? data.batteryTemperature;
-      if (batteryTempValue !== undefined) {
-        this.log('[DATA] Battery temperature found:', batteryTempValue);
-        await this.setCapabilityValue('measure_battery_temperature', parseFloat(batteryTempValue));
-      }
-
-      // Debug: Log all attributes containing 'temp' or 'battery' to find correct key
-      const tempBatteryKeys = Object.keys(data).filter(k =>
-        k.toLowerCase().includes('temp') || k.toLowerCase().includes('battery')
-      );
-      if (tempBatteryKeys.length > 0) {
-        this.log('[DEBUG] Temperature/Battery related attributes:', tempBatteryKeys.map(k => `${k}=${data[k]}`).join(', '));
-      }
-
-      // Preconditioning status - check both lowercase and camelCase variants
-      const precondActiveValue = data.precondactive ?? data.precondActive;
-      if (precondActiveValue !== undefined) {
-        const precondActive = precondActiveValue === true || precondActiveValue === 'true' || precondActiveValue === 1;
-        await this.setCapabilityValue('onoff_precond', precondActive);
-      }
-
-      // Auxiliary heating status - check both lowercase and camelCase variants
-      const auxheatActiveValue = data.auxheatactive ?? data.auxheatActive;
-      if (auxheatActiveValue !== undefined) {
-        const auxheatActive = auxheatActiveValue === true || auxheatActiveValue === 'true' || auxheatActiveValue === 1;
-        await this.setCapabilityValue('onoff_auxheat', auxheatActive);
-      }
-
-      // Remote start status - check both lowercase and camelCase variants
-      const remoteStartActiveValue = data.remotestartactive ?? data.remoteStartActive;
-      if (remoteStartActiveValue !== undefined) {
-        const remoteStartActive = remoteStartActiveValue === true || remoteStartActiveValue === 'true' || remoteStartActiveValue === 1;
-        await this.setCapabilityValue('onoff_remote_start', remoteStartActive);
-      }
-
-      // Theft system armed status - check both lowercase and camelCase variants
-      const theftSystemArmedValue = data.theftsystemarmed ?? data.theftSystemArmed;
-      if (theftSystemArmedValue !== undefined) {
-        const theftArmed = theftSystemArmedValue === true || theftSystemArmedValue === 'true' || theftSystemArmedValue === 1;
-        await this.setCapabilityValue('theft_system_armed', theftArmed);
-      }
-
-      // Theft alarm status - check both lowercase and camelCase variants
-      const theftAlarmActiveValue = data.theftalarmactive ?? data.theftAlarmActive;
-      const lastTheftWarningValue = data.lasttheftwarning ?? data.lastTheftWarning;
-      if (theftAlarmActiveValue !== undefined || lastTheftWarningValue !== undefined) {
-        const theftActive = theftAlarmActiveValue === true || theftAlarmActiveValue === 1;
-        const wasTheftActive = this.getCapabilityValue('alarm_theft');
-        await this.setCapabilityValue('alarm_theft', theftActive);
-
-        // Trigger vehicle alarm flow card when alarm activates
-        if (theftActive && !wasTheftActive) {
-          const reasonValue = data.lasttheftwarningreason ?? data.lastTheftWarningReason;
-          const reason = reasonValue || 'UNKNOWN';
-          await this.homey.flow.getDeviceTriggerCard('vehicle_alarm')
-            .trigger(this, { reason: String(reason) });
+      try {
+        const batteryTempValue = data.temperaturehvbattery ?? data.temperatureHVBattery ??
+          data.hvbatterytemperature ?? data.hvBatteryTemperature ??
+          data.ecoelectricbatterytemperature ?? data.ecoElectricBatteryTemperature ??
+          data.batterytemperature ?? data.batteryTemperature;
+        if (batteryTempValue !== undefined) {
+          this.log('[DATA] Battery temperature found:', batteryTempValue);
+          await this.setCapabilityValue('measure_battery_temperature', parseFloat(batteryTempValue));
         }
+
+        // Debug: Log all attributes containing 'temp' or 'battery' to find correct key
+        const tempBatteryKeys = Object.keys(data).filter(k =>
+          k.toLowerCase().includes('temp') || k.toLowerCase().includes('battery')
+        );
+        if (tempBatteryKeys.length > 0) {
+          this.log('[DEBUG] Temperature/Battery related attributes:', tempBatteryKeys.map(k => `${k}=${data[k]}`).join(', '));
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating battery temperature:', e.message);
+      }
+
+      // Preconditioning / auxiliary heating / remote start status - check both lowercase and camelCase variants
+      try {
+        const precondActiveValue = data.precondactive ?? data.precondActive;
+        if (precondActiveValue !== undefined) {
+          const precondActive = precondActiveValue === true || precondActiveValue === 'true' || precondActiveValue === 1;
+          await this.setCapabilityValue('onoff_precond', precondActive);
+        }
+
+        const auxheatActiveValue = data.auxheatactive ?? data.auxheatActive;
+        if (auxheatActiveValue !== undefined) {
+          const auxheatActive = auxheatActiveValue === true || auxheatActiveValue === 'true' || auxheatActiveValue === 1;
+          await this.setCapabilityValue('onoff_auxheat', auxheatActive);
+        }
+
+        const remoteStartActiveValue = data.remotestartactive ?? data.remoteStartActive;
+        if (remoteStartActiveValue !== undefined) {
+          const remoteStartActive = remoteStartActiveValue === true || remoteStartActiveValue === 'true' || remoteStartActiveValue === 1;
+          await this.setCapabilityValue('onoff_remote_start', remoteStartActive);
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating precond/auxheat/remote start:', e.message);
+      }
+
+      // Theft system armed / theft alarm status - check both lowercase and camelCase variants
+      try {
+        const theftSystemArmedValue = data.theftsystemarmed ?? data.theftSystemArmed;
+        if (theftSystemArmedValue !== undefined) {
+          const theftArmed = theftSystemArmedValue === true || theftSystemArmedValue === 'true' || theftSystemArmedValue === 1;
+          await this.setCapabilityValue('theft_system_armed', theftArmed);
+        }
+
+        const theftAlarmActiveValue = data.theftalarmactive ?? data.theftAlarmActive;
+        const lastTheftWarningValue = data.lasttheftwarning ?? data.lastTheftWarning;
+        if (theftAlarmActiveValue !== undefined || lastTheftWarningValue !== undefined) {
+          const theftActive = theftAlarmActiveValue === true || theftAlarmActiveValue === 1;
+          const wasTheftActive = this.getCapabilityValue('alarm_theft');
+          await this.setCapabilityValue('alarm_theft', theftActive);
+
+          // Trigger vehicle alarm flow card when alarm activates
+          if (theftActive && !wasTheftActive) {
+            const reasonValue = data.lasttheftwarningreason ?? data.lastTheftWarningReason;
+            const reason = reasonValue || 'UNKNOWN';
+            await this.homey.flow.getDeviceTriggerCard('vehicle_alarm')
+              .trigger(this, { reason: String(reason) });
+          }
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating theft system/alarm status:', e.message);
       }
 
       // Geofence data from WebSocket (if available) - check multiple possible field names
-      const geofenceZone = data.geofencename ?? data.geofenceName ?? data.geofence_name ??
-                           data.lastgeofencezone ?? data.lastGeofenceZone ?? data.currentzone ?? data.currentZone;
-      if (geofenceZone !== undefined) {
-        this.log(`[UPDATE] Setting geofence zone to: ${geofenceZone}`);
-        await this.setCapabilityValue('text_geofence_last_zone', String(geofenceZone));
-      }
+      try {
+        const geofenceZone = data.geofencename ?? data.geofenceName ?? data.geofence_name ??
+                             data.lastgeofencezone ?? data.lastGeofenceZone ?? data.currentzone ?? data.currentZone;
+        if (geofenceZone !== undefined) {
+          this.log(`[UPDATE] Setting geofence zone to: ${geofenceZone}`);
+          await this.setCapabilityValue('text_geofence_last_zone', String(geofenceZone));
+        }
 
-      const geofenceEvent = data.geofenceevent ?? data.geofenceEvent ?? data.geofence_event ??
-                            data.lastgeofenceevent ?? data.lastGeofenceEvent;
-      if (geofenceEvent !== undefined) {
-        this.log(`[UPDATE] Setting geofence event to: ${geofenceEvent}`);
-        await this.setCapabilityValue('text_geofence_last_event', String(geofenceEvent));
+        const geofenceEvent = data.geofenceevent ?? data.geofenceEvent ?? data.geofence_event ??
+                              data.lastgeofenceevent ?? data.lastGeofenceEvent;
+        if (geofenceEvent !== undefined) {
+          this.log(`[UPDATE] Setting geofence event to: ${geofenceEvent}`);
+          await this.setCapabilityValue('text_geofence_last_event', String(geofenceEvent));
+        }
+      } catch (e) {
+        this.error('[UPDATE] Error updating geofence zone/event:', e.message);
       }
 
       this.log('Capabilities updated successfully');
 
     } catch (error) {
       this.error('Error updating capabilities:', error.message);
+      this.error('Error stack:', error.stack);
     }
   }
 

--- a/drivers/mercedes-vehicle/driver.js
+++ b/drivers/mercedes-vehicle/driver.js
@@ -2,12 +2,14 @@
 
 const Homey = require('homey');
 const MercedesOAuth = require('../../lib/oauth');
+const { installRedactedLogging } = require('../../lib/log-redactor');
 
 class MercedesVehicleDriver extends Homey.Driver {
   /**
    * onInit is called when the driver is initialized.
    */
   async onInit() {
+    installRedactedLogging(this);
     this.log('Mercedes Vehicle Driver has been initialized');
 
     // Register flow card handlers
@@ -378,8 +380,9 @@ class MercedesVehicleDriver extends Homey.Driver {
       }
 
       return vehicles.map(vehicle => {
-        // Log the vehicle object to see what fields are available
-        this.log('Vehicle data:', JSON.stringify(vehicle, null, 2));
+        // Log the available field names only - the vehicle object itself
+        // carries VIN/license plate and possibly other account-linked data.
+        this.log('Vehicle data keys:', Object.keys(vehicle).join(', '));
 
         // Use vin or fin (matches HA implementation)
         const vin = vehicle.vin || vehicle.fin || 'UNKNOWN';
@@ -450,7 +453,9 @@ class MercedesVehicleDriver extends Homey.Driver {
           }
         };
 
-        this.log('Device object created:', JSON.stringify(deviceObj, null, 2));
+        // Deliberately not logging the full deviceObj: its `store` carries
+        // the plaintext account password and OAuth token.
+        this.log('Device object created:', deviceObj.name, 'capabilities:', deviceObj.capabilities.length);
         return deviceObj;
       });
     });

--- a/lib/log-redactor.js
+++ b/lib/log-redactor.js
@@ -2,37 +2,122 @@
 
 // VIN: 17-char ISO 3779 identifier (letters minus I/O/Q, plus digits).
 const VIN_RE = /\b[A-HJ-NPR-Z0-9]{17}\b/g;
+const VIN_TEST_RE = /\b[A-HJ-NPR-Z0-9]{17}\b/;
+
+// Email addresses (Mercedes Me login is an email).
+const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
 
 // Coordinates are only redacted next to their identifying label, so
 // operational floats (tire pressure, SoC, ranges, ...) stay intact.
-const LAT_RE = /(latitude[^0-9-]{0,30})(-?\d{1,3}\.\d+)/gi;
-const LON_RE = /(longitude[^0-9-]{0,30})(-?\d{1,3}\.\d+)/gi;
+// Covers both prose ("Setting latitude from geofence: ...") and the raw
+// protobuf attribute name ("positionLat":{"doubleValue":...}).
+const LAT_RE = /((?:latitude|positionlat)[^0-9-]{0,30})(-?\d{1,3}\.\d+)/gi;
+const LON_RE = /((?:longitude|positionlong)[^0-9-]{0,30})(-?\d{1,3}\.\d+)/gi;
 
-// Geofence zone names are user-authored labels (e.g. "Home").
+// Geofence zone names are user-authored labels (e.g. "Home"), logged both
+// as prose ("snapshot.name: "Home"") and inside raw JSON event dumps.
 const ZONE_NAME_RE = /((?:snapshot|fence)\.name\s*:\s*)"[^"]*"/gi;
 const ZONE_VALUE_RE = /(Setting geofence zone to:\s*)(\S+)/gi;
+
+// Account-linked geofence IDs: redact large IDs, but leave structural
+// zeros (e.g. `"id":0` on a snapshot) alone.
+const FENCE_ID_RE = /("fenceId"\s*:\s*)\d+/gi;
+const VIOLATION_ID_RE = /("id"\s*:\s*)\d{6,}/gi;
+
+// Credentials and account-linked identifiers that show up as JSON-key/value
+// pairs when a whole object (login payload, paired-device object, OAuth
+// token) gets JSON.stringify'd into a log line.
+const SENSITIVE_KEY_PLACEHOLDER = {
+  password: 'PASSWORD',
+  token: 'TOKEN',
+  access_token: 'TOKEN',
+  accesstoken: 'TOKEN',
+  refresh_token: 'TOKEN',
+  refreshtoken: 'TOKEN',
+  id_token: 'TOKEN',
+  idtoken: 'TOKEN',
+  username: 'EMAIL',
+  licenseplate: 'LICENSE_PLATE',
+  deviceguid: 'DEVICE_ID',
+  pin: 'PIN',
+  name: 'ZONE',
+};
+const SENSITIVE_KEY_RE = new RegExp(
+  `"(${Object.keys(SENSITIVE_KEY_PLACEHOLDER).join('|')})"(\\s*:\\s*)("[^"]*"|\\{[^{}]*\\}|[^,}\\]]+)`,
+  'gi',
+);
 
 function redactText(text) {
   return text
     .replace(VIN_RE, '[VIN_REDACTED]')
+    .replace(EMAIL_RE, '[EMAIL_REDACTED]')
     .replace(LAT_RE, (match, prefix) => `${prefix}[LAT_REDACTED]`)
     .replace(LON_RE, (match, prefix) => `${prefix}[LON_REDACTED]`)
     .replace(ZONE_NAME_RE, (match, prefix) => `${prefix}"[ZONE_REDACTED]"`)
-    .replace(ZONE_VALUE_RE, (match, prefix) => `${prefix}[ZONE_REDACTED]`);
-}
-
-function redactArg(arg) {
-  return typeof arg === 'string' ? redactText(arg) : arg;
+    .replace(ZONE_VALUE_RE, (match, prefix) => `${prefix}[ZONE_REDACTED]`)
+    .replace(FENCE_ID_RE, (match, prefix) => `${prefix}[FENCE_ID_REDACTED]`)
+    .replace(VIOLATION_ID_RE, (match, prefix) => `${prefix}[VIOLATION_ID_REDACTED]`)
+    .replace(SENSITIVE_KEY_RE, (match, key, sep) => {
+      const placeholder = SENSITIVE_KEY_PLACEHOLDER[key.toLowerCase()];
+      return `"${key}"${sep}"[${placeholder}_REDACTED]"`;
+    });
 }
 
 /**
- * Wraps log/error on a Homey App/Driver/Device instance so VIN, GPS
- * coordinates and geofence zone names never reach the log output that
+ * Scans hex-dumped byte buffers (e.g. `buffer.toString('hex')`) for a VIN
+ * hiding in the decoded bytes and redacts just that slice of hex, leaving
+ * the surrounding protobuf framing bytes untouched. Must run after the
+ * plaintext passes so a hex-encoded copy can't survive just because the
+ * plaintext copy nearby was already caught.
+ */
+function redactHexEncodedVin(text) {
+  return text.replace(/\b(?:[0-9a-fA-F]{2}){10,}\b/g, (hexRun) => {
+    let ascii = '';
+    for (let i = 0; i < hexRun.length; i += 2) {
+      ascii += String.fromCharCode(parseInt(hexRun.substr(i, 2), 16));
+    }
+    const match = ascii.match(VIN_TEST_RE);
+    if (!match) return hexRun;
+
+    const hexStart = match.index * 2;
+    const hexLen = match[0].length * 2;
+    return `${hexRun.slice(0, hexStart)}[HEX_VIN_REDACTED]${hexRun.slice(hexStart + hexLen)}`;
+  });
+}
+
+function redactAllText(text) {
+  return redactHexEncodedVin(redactText(text));
+}
+
+/**
+ * Recursively redacts strings found anywhere in a value - not just a bare
+ * string argument, but also plain objects/arrays (e.g. the object
+ * `_describeError()` builds from an axios error) that get passed straight
+ * to log/error and would otherwise bypass string-only scrubbing.
+ */
+function redactValue(value, seen = new WeakSet(), depth = 0) {
+  if (typeof value === 'string') return redactAllText(value);
+  if (!value || typeof value !== 'object' || depth > 5) return value;
+  if (value instanceof Error) return value;
+  if (seen.has(value)) return value;
+  seen.add(value);
+
+  if (Array.isArray(value)) return value.map((item) => redactValue(item, seen, depth + 1));
+
+  const out = {};
+  for (const [key, val] of Object.entries(value)) out[key] = redactValue(val, seen, depth + 1);
+  return out;
+}
+
+/**
+ * Wraps log/error on a Homey App/Driver/Device instance so VIN (plaintext
+ * and hex-encoded), GPS coordinates, geofence zone/fence IDs, login email,
+ * and credentials (password/OAuth token) never reach the log output that
  * diagnostic reports are built from.
  *
  * Defines a new own property rather than assigning to `log`/`error`
- * directly: those are inherited getters on the Homey SDK prototype with
- * no setter, so `instance.log = ...` throws "Cannot assign to read only
+ * directly: those are non-writable properties on Homey App/Driver/Device
+ * instances, so `instance.log = ...` throws "Cannot assign to read only
  * property" under strict mode. `Object.defineProperty` creates a new own
  * property that shadows the inherited one instead of writing through it.
  */
@@ -43,7 +128,7 @@ function installRedactedLogging(instance) {
 
     const bound = original.bind(instance);
     Object.defineProperty(instance, methodName, {
-      value: (...args) => bound(...args.map(redactArg)),
+      value: (...args) => bound(...args.map((arg) => redactValue(arg))),
       writable: true,
       configurable: true,
       enumerable: false,
@@ -51,4 +136,4 @@ function installRedactedLogging(instance) {
   }
 }
 
-module.exports = { installRedactedLogging, redactText };
+module.exports = { installRedactedLogging, redactText: redactAllText, redactValue };

--- a/lib/proto/parser.js
+++ b/lib/proto/parser.js
@@ -424,7 +424,9 @@ class ProtoParser {
       this.homey.app.log('[PARSER] Created command message:', JSON.stringify(commandData), 'requestId:', requestId);
 
       const buffer = Buffer.from(this.CommandClientMessage.encode(message).finish());
-      this.homey.app.log('[PARSER] Command buffer hex:', buffer.toString('hex'));
+      // Not logging the raw hex buffer: unlike the vehicle-data hex dumps
+      // (where a VIN can be found and redacted by shape), a PIN command's
+      // encoded bytes carry the PIN with no reliable byte-pattern to redact.
       this.homey.app.log('[PARSER] Command buffer length:', buffer.length, 'bytes');
       return { buffer, requestId };
     } catch (error) {

--- a/test/log-redactor.test.js
+++ b/test/log-redactor.test.js
@@ -2,7 +2,7 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { redactText, installRedactedLogging } = require('../lib/log-redactor');
+const { redactText, redactValue, installRedactedLogging } = require('../lib/log-redactor');
 
 test('redacts a VIN', () => {
   const out = redactText('VIN: WDD2050461R123456, Region: Europe');
@@ -37,6 +37,100 @@ test('redacts geofence zone names, quoted and unquoted', () => {
 test('preserves non-PII telemetry', () => {
   const line = 'Setting odometer to: 73449 km, battery to: 78%, driving time to: 15 min';
   assert.equal(redactText(line), line);
+});
+
+test('redacts raw protobuf position attribute names, not just prose', () => {
+  const line = '"positionLat":{"doubleValue":55.676098},"positionLong":{"doubleValue":12.568337}';
+  assert.equal(
+    redactText(line),
+    '"positionLat":{"doubleValue":[LAT_REDACTED]},"positionLong":{"doubleValue":[LON_REDACTED]}',
+  );
+});
+
+test('redacts the device.js "Setting location" line', () => {
+  assert.equal(
+    redactText('[UPDATE] Setting location - latitude: 55.676098, longitude: 12.568337'),
+    '[UPDATE] Setting location - latitude: [LAT_REDACTED], longitude: [LON_REDACTED]',
+  );
+});
+
+test('redacts email addresses', () => {
+  assert.equal(
+    redactText('Login attempt with email: someone@example.com (selected region: Europe)'),
+    'Login attempt with email: [EMAIL_REDACTED] (selected region: Europe)',
+  );
+});
+
+test('redacts credentials and account-linked IDs embedded in JSON dumps', () => {
+  const deviceObj = JSON.stringify({
+    name: 'Mercedes-Benz (AB-123-CD)',
+    store: {
+      username: 'someone@example.com',
+      password: 'hunter2',
+      region: 'Europe',
+      deviceGuid: '0f4a1c2e-1111-2222-3333-abcdefabcdef',
+      token: { access_token: 'abc.def.ghi', refresh_token: 'r-123' },
+    },
+  });
+  const redacted = redactText(deviceObj);
+
+  assert.ok(!redacted.includes('hunter2'), 'password must not survive');
+  assert.ok(!redacted.includes('someone@example.com'), 'username/email must not survive');
+  assert.ok(!redacted.includes('AB-123-CD'), 'license-plate-bearing name must not survive');
+  assert.ok(!redacted.includes('0f4a1c2e-1111-2222-3333-abcdefabcdef'), 'deviceGuid must not survive');
+  assert.ok(!redacted.includes('abc.def.ghi') && !redacted.includes('r-123'), 'OAuth tokens must not survive');
+  assert.ok(redacted.includes('[PASSWORD_REDACTED]'));
+});
+
+test('redacts a PIN passed to a vehicle command', () => {
+  const commandData = JSON.stringify({ doorsUnlock: { pin: '1234', doors: [] } });
+  const redacted = redactText(commandData);
+  assert.ok(!redacted.includes('1234'));
+  assert.ok(redacted.includes('[PIN_REDACTED]'));
+});
+
+test('redacts large geofence fenceId/violation id, keeps structural zeros', () => {
+  const line = '{"fenceId":48213099,"id":918273645,"snapshot":{"id":0,"isActive":false}}';
+  const redacted = redactText(line);
+  assert.ok(redacted.includes('[FENCE_ID_REDACTED]'));
+  assert.ok(redacted.includes('[VIOLATION_ID_REDACTED]'));
+  assert.ok(redacted.includes('"id":0'), 'structural zero id must survive');
+  assert.ok(!redacted.includes('48213099') && !redacted.includes('918273645'));
+});
+
+test('redacts a VIN hex-encoded inside a protobuf byte dump, leaving framing bytes', () => {
+  const vin = 'WDD2050461R123456';
+  const framingBefore = Buffer.from([0x12, 0x11]);
+  const framingAfter = Buffer.from([0x29, 0x0a, 0x0f]);
+  const buffer = Buffer.concat([framingBefore, Buffer.from(vin, 'ascii'), framingAfter]);
+  const line = `First 50 bytes (hex): ${buffer.toString('hex')}`;
+
+  const redacted = redactText(line);
+  assert.ok(redacted.includes('[HEX_VIN_REDACTED]'));
+  assert.ok(redacted.includes(framingBefore.toString('hex')), 'framing bytes before the VIN must survive');
+  assert.ok(redacted.includes(framingAfter.toString('hex')), 'framing bytes after the VIN must survive');
+  assert.ok(!redacted.includes(Buffer.from(vin, 'ascii').toString('hex')), 'hex-encoded VIN bytes must not survive');
+});
+
+test('redactValue recursively redacts plain objects/arrays passed as a log arg', () => {
+  const described = {
+    message: 'Request failed with status code 400',
+    status: 400,
+    body: 'VIN WDD2050461R123456 not found for someone@example.com',
+  };
+  const redacted = redactValue(described);
+  assert.equal(redacted.status, 400);
+  assert.ok(!redacted.body.includes('WDD2050461R123456'));
+  assert.ok(!redacted.body.includes('someone@example.com'));
+});
+
+test('redactValue leaves Error instances untouched and tolerates circular refs', () => {
+  const err = new Error('boom');
+  assert.equal(redactValue(err), err);
+
+  const circular = { name: 'x' };
+  circular.self = circular;
+  assert.doesNotThrow(() => redactValue(circular));
 });
 
 test('installRedactedLogging does not crash on a non-writable log/error property', () => {


### PR DESCRIPTION
## Summary

Follow-up to #48 (merged), which only fixed the crash from issue #47's last comment. This PR addresses the two things still open per the issue: the original "not all capabilities are refreshed" bug, and full PII/credential removal from logs.

**Root cause of the capabilities bug** (found via focused code trace, not the log excerpt in the issue body): `updateCapabilities()` in `device.js` wrapped ~20 field-update blocks (door lock, battery, charging, engine state, tire pressure, position, door/window status, etc.) in a single function-wide `try/catch`. If any unguarded block threw partway through processing a push, every capability scheduled after that point — door state included, since it sits well past a dozen other blocks — silently never updated for that push, even though everything before the failure had already applied. Only the window/door mapping loops had per-item isolation; nothing else did.

- Wrapped each remaining field group in its own `try/catch` (mirroring the pattern already used for the window/door loops), so one field's exception can no longer abort every field after it. Verified the exact same set of `setCapabilityValue`/`getDeviceTriggerCard`/`hasCapability` calls exists before and after (diffed as sorted call lists — identical).
- The outer `catch` now also logs `error.stack`, not just `error.message`, so any error that still slips through is diagnosable.

**Remaining PII/credential leaks**, found by auditing every `log`/`error` call site in the app (not just what the issue described):
- `driver.js` logged the entire paired-device object and the raw vehicle object during pairing — including the **plaintext account password and OAuth token** in `deviceObj.store`. Replaced both with non-sensitive summaries.
- `lib/proto/parser.js` logged a command's raw encoded hex buffer, which can carry a vehicle **PIN** with no reliable byte-pattern to redact (unlike a VIN). Removed; the buffer length is still logged.
- `lib/log-redactor.js` (added in #48) now also redacts: login email, and password/OAuth token/PIN/license plate/device GUID/zone name when embedded in JSON-serialized log lines (e.g. the paired-device dump, geofence event dumps); large geofence `fenceId`/violation `id` (structural `"id":0` left alone); VIN hex-encoded inside protobuf byte dumps (decodes the hex, finds the VIN by shape, redacts just that byte range); and recursively redacts plain objects/arrays passed directly to `log`/`error` (previously only bare string arguments were scrubbed, so e.g. `this.error('...', someObject)` bypassed it entirely).
- `driver.js`'s own `log`/`error` are now wrapped too (previously only `app.js` and `device.js` were).

Out of scope, deliberately: the `[Device:UUID]` prefix Homey's own log viewer adds to device log lines. That's an internal identifier for which paired device a line came from, not something that reveals a person's identity, location, or account — not PII, so nothing to redact there.

## Test plan
- [x] `npm test` — 14 tests (`test/log-redactor.test.js`), including new coverage for email, credentials/PIN/license-plate/device-GUID in JSON dumps, fenceId/violation-id redaction with structural-zero preservation, hex-encoded VIN detection, and recursive object redaction.
- [x] `node -c` on every touched file.
- [x] Diffed the full set of `setCapabilityValue`/`getDeviceTriggerCard`/`hasCapability` calls in `device.js` before vs. after the refactor — identical, confirming no logic was dropped or duplicated while adding per-block isolation.