### PR TITLE
Fix repeat crash: Homey log/error is non-configurable, not just non-writable (issue #47)

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const { installRedactedLogging } = require('./lib/log-redactor');
 class MercedesMeApp extends Homey.App {
 
   async onInit() {
-    installRedactedLogging(this);
+    installRedactedLogging();
     this.log('Mercedes-Benz app has been initialized');
     this._installCrashHandlers();
     this._logLastCrash();

--- a/drivers/mercedes-vehicle/device.js
+++ b/drivers/mercedes-vehicle/device.js
@@ -10,7 +10,7 @@ class MercedesVehicleDevice extends Homey.Device {
    * onInit is called when the device is initialized.
    */
   async onInit() {
-    installRedactedLogging(this);
+    installRedactedLogging();
     this.log('Mercedes Vehicle device initializing...');
 
     const settings = this.getSettings();

--- a/drivers/mercedes-vehicle/driver.js
+++ b/drivers/mercedes-vehicle/driver.js
@@ -9,7 +9,7 @@ class MercedesVehicleDriver extends Homey.Driver {
    * onInit is called when the driver is initialized.
    */
   async onInit() {
-    installRedactedLogging(this);
+    installRedactedLogging();
     this.log('Mercedes Vehicle Driver has been initialized');
 
     // Register flow card handlers

--- a/lib/log-redactor.js
+++ b/lib/log-redactor.js
@@ -109,30 +109,36 @@ function redactValue(value, seen = new WeakSet(), depth = 0) {
   return out;
 }
 
+let consoleRedactionInstalled = false;
+
 /**
- * Wraps log/error on a Homey App/Driver/Device instance so VIN (plaintext
- * and hex-encoded), GPS coordinates, geofence zone/fence IDs, login email,
- * and credentials (password/OAuth token) never reach the log output that
+ * Patches the global console.log/error/warn/info so VIN (plaintext and
+ * hex-encoded), GPS coordinates, geofence zone/fence IDs, login email, and
+ * credentials (password/OAuth token) never reach the log output that
  * diagnostic reports are built from.
  *
- * Defines a new own property rather than assigning to `log`/`error`
- * directly: those are non-writable properties on Homey App/Driver/Device
- * instances, so `instance.log = ...` throws "Cannot assign to read only
- * property" under strict mode. `Object.defineProperty` creates a new own
- * property that shadows the inherited one instead of writing through it.
+ * Homey.App/Driver/Device instances expose `log`/`error` as non-writable,
+ * non-configurable own properties - confirmed by two separate crashes
+ * against real code: `instance.log = fn` throws "Cannot assign to read
+ * only property" (non-writable), and `Object.defineProperty(instance,
+ * 'log', ...)` throws "Cannot redefine property" (non-configurable). The
+ * instance property can't be touched at all, in either direction. Since
+ * every one of those methods ultimately writes through to stdout/stderr
+ * (that's what the Homey log viewer streams from), patching the global
+ * `console` object is the only interception point that actually works.
+ * Idempotent and safe to call from every onInit - only the first call
+ * does anything.
  */
-function installRedactedLogging(instance) {
-  for (const methodName of ['log', 'error']) {
-    const original = instance[methodName];
+function installRedactedLogging() {
+  if (consoleRedactionInstalled) return;
+  consoleRedactionInstalled = true;
+
+  for (const methodName of ['log', 'error', 'warn', 'info']) {
+    const original = console[methodName];
     if (typeof original !== 'function') continue;
 
-    const bound = original.bind(instance);
-    Object.defineProperty(instance, methodName, {
-      value: (...args) => bound(...args.map((arg) => redactValue(arg))),
-      writable: true,
-      configurable: true,
-      enumerable: false,
-    });
+    const bound = original.bind(console);
+    console[methodName] = (...args) => bound(...args.map((arg) => redactValue(arg)));
   }
 }
 

--- a/test/log-redactor.test.js
+++ b/test/log-redactor.test.js
@@ -133,23 +133,26 @@ test('redactValue leaves Error instances untouched and tolerates circular refs',
   assert.doesNotThrow(() => redactValue(circular));
 });
 
-test('installRedactedLogging does not crash on a non-writable log/error property', () => {
-  // Mirrors the Homey SDK App/Device instance: `log`/`error` are defined
-  // as non-writable own properties, so `instance.log = fn` throws
-  // "Cannot assign to read only property" under strict mode (the crash
-  // reported against v1.1.33).
+test('installRedactedLogging works against a non-writable AND non-configurable log/error property', () => {
+  // Mirrors the real Homey SDK App/Driver/Device instance. Two separate
+  // production crashes proved `log`/`error` can't be touched at all:
+  // `instance.log = fn` throws "Cannot assign to read only property"
+  // (non-writable, v1.1.33), and `Object.defineProperty(instance, 'log',
+  // ...)` throws "Cannot redefine property" (non-configurable, v1.1.34).
+  // installRedactedLogging must not go anywhere near the instance
+  // property at all - it patches the global console instead.
   class FakeHomeyBase {
     constructor() {
       Object.defineProperty(this, 'log', {
-        value: (...args) => { this.lastLog = args; },
+        value: (...args) => console.log(...args),
         writable: false,
-        configurable: true,
+        configurable: false,
         enumerable: false,
       });
       Object.defineProperty(this, 'error', {
-        value: (...args) => { this.lastError = args; },
+        value: (...args) => console.error(...args),
         writable: false,
-        configurable: true,
+        configurable: false,
         enumerable: false,
       });
     }
@@ -157,11 +160,26 @@ test('installRedactedLogging does not crash on a non-writable log/error property
   const instance = new FakeHomeyBase();
 
   assert.throws(() => { instance.log = () => {}; }, TypeError);
-  assert.doesNotThrow(() => installRedactedLogging(instance));
+  assert.throws(() => {
+    Object.defineProperty(instance, 'log', { value: () => {}, configurable: true });
+  }, TypeError);
 
-  instance.log('VIN: WDD2050461R123456');
-  assert.deepEqual(instance.lastLog, ['VIN: [VIN_REDACTED]']);
+  const originalConsoleLog = console.log;
+  const originalConsoleError = console.error;
+  const seenLog = [];
+  const seenError = [];
+  console.log = (...args) => seenLog.push(args);
+  console.error = (...args) => seenError.push(args);
+  try {
+    assert.doesNotThrow(() => installRedactedLogging());
 
-  instance.error('failed:', 'VIN: WDD2050461R123456');
-  assert.deepEqual(instance.lastError, ['failed:', 'VIN: [VIN_REDACTED]']);
+    instance.log('VIN: WDD2050461R123456');
+    instance.error('failed:', 'VIN: WDD2050461R123456');
+  } finally {
+    console.log = originalConsoleLog;
+    console.error = originalConsoleError;
+  }
+
+  assert.deepEqual(seenLog[0], ['VIN: [VIN_REDACTED]']);
+  assert.deepEqual(seenError[0], ['failed:', 'VIN: [VIN_REDACTED]']);
 });


### PR DESCRIPTION
## Summary

Follow-up to #48 and #49 (both merged). v1.1.34's newest error report shows the app is still crashing on startup, with a new error:

```
CreateClientError: Cannot redefine property: log
TypeError: Cannot redefine property: log
    at Function.defineProperty (<anonymous>)
    at installRedactedLogging (/app/lib/log-redactor.js:130:12)
    at MercedesMeApp.onInit (/app/app.js:9:5)
```

**Root cause:** #48's fix assumed `log`/`error` on Homey App/Driver/Device instances were non-writable but *configurable* data properties — true only for the plain-assignment crash it was fixing (`instance.log = fn` throws "Cannot assign to read only property" regardless of configurability). It was still wrong: the real instances expose `log`/`error` as non-writable **and non-configurable**, so `Object.defineProperty(instance, 'log', ...)` throws "Cannot redefine property" too. Two separate production crashes now confirm the instance property can't be touched in either direction — not by assignment, not by redefinition.

**Fix:** stopped trying to touch the instance property at all. Every one of these logging methods ultimately writes through to stdout/stderr (that's what the Homey log viewer streams from), so `installRedactedLogging()` now patches the global `console.log`/`error`/`warn`/`info` once, idempotently, instead. Callers (`app.js`, `driver.js`, `device.js`) no longer pass an instance — it's a one-time, process-wide install.

## Test plan
- [x] `npm test` — 14 tests, including a rewritten regression test that reproduces both prior crash modes (non-writable *and* non-configurable `log`/`error`, matching the real SDK) and verifies redaction still reaches the console.
- [x] `node -c` on every touched file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDmJveEAQ35eUsSd5HhxhQ)_