### PR TITLE
Exclude dev-only files from the published app bundle

### DIFF
--- a/.homeyignore
+++ b/.homeyignore
@@ -1,0 +1,16 @@
+# Files excluded from the published Homey app bundle.
+#
+# These are development-only: they are never require()d by app.js, the
+# driver, the device or the widget, so shipping them only inflates the
+# build. Runtime code (lib/, drivers/, widgets/, assets/, locales/,
+# app.json, README.txt) is deliberately NOT listed here.
+
+# Unit tests
+test/
+*.test.js
+
+# CI configuration
+.github/
+
+# Developer documentation (README.txt is the store description and must ship)
+WEBSOCKET_RECONNECT_ANALYSIS.md


### PR DESCRIPTION
## Summary

The repo has no `.homeyignore`, so **every** file is bundled into the published build — the last publish reported 895 files. That includes unit tests, the CI workflow definitions and the WebSocket analysis document, none of which are ever `require()`d by `app.js`, the driver, the device or the widget.

Adds a `.homeyignore` excluding:
- `test/` and `*.test.js`
- `.github/`
- `WEBSOCKET_RECONNECT_ANALYSIS.md`

Runtime code (`lib/`, `drivers/`, `widgets/`, `assets/`, `locales/`, `app.json`) and `README.txt` (the store description, which Homey publish validation requires) are deliberately **not** excluded.

This is a packaging change only — the tests remain in the repo and still run via `npm test` and in CI.

### Context: there was no unused redactor to delete

This started as a request to remove duplicate/unused log-redactor files. Worth recording that there aren't any in `main`:

| File in `main` | Status |
| --- | --- |
| `lib/log-redactor.js` | **Live runtime code** — `require`d by `app.js`, `device.js` and `driver.js`; `installRedactedLogging()` runs in every `onInit()`. Must stay. |
| `test/log-redactor.test.js` | Test only — kept in the repo, now excluded from the bundle. |

The other redactor files (`lib/redact.js`, `scripts/redact-log.js`, `scripts/redact-log.test.js`, `scripts/README-redact-log.md`) exist **only** on the unmerged `47-bug---not-all-capabilities-are-not-refreshed` branch and have never been part of the app. On that branch `lib/redact.js` is itself runtime code (its `log-redactor.js` requires it at line 3), so it isn't tooling either — only the `scripts/` CLI is.

## Test plan
- [x] `npx homey app validate --level publish` — passes with `.homeyignore` in place.
- [x] `npm test` — 23 tests still passing.
- [x] Confirmed `lib/log-redactor.js` is required by 3 runtime files and is not excluded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDmJveEAQ35eUsSd5HhxhQ)_