### PR TITLE
Fix dashboard widget getting stuck and refreshing too slowly (issue #53)

### DIFF
--- a/widgets/car-status/public/index.html
+++ b/widgets/car-status/public/index.html
@@ -280,6 +280,10 @@
 
   function update(data) {
     document.getElementById('loading').classList.add('hidden');
+    // The not-configured panel is full height, so leaving it visible would
+    // cover the content we are about to render. It must be hidden here or a
+    // single transient not-configured response latches the widget forever.
+    document.getElementById('notConfigured').classList.add('hidden');
     document.getElementById('content').classList.remove('hidden');
 
     document.getElementById('modelName').textContent = data.model || 'Mercedes-Benz';
@@ -363,29 +367,50 @@
   var selectedDeviceId = null;
   var _homey = null;
 
+  // The widget endpoint only reads already-cached capability values from
+  // Homey - it never calls the Mercedes API - so it is deliberately NOT tied
+  // to the device's `polling_interval` setting. That setting rate-limits
+  // backend calls and can be up to an hour, which would leave the dashboard
+  // an hour stale even while the app receives real-time WebSocket pushes.
+  var REFRESH_INTERVAL = 15000; // 15 seconds
+
+  var hasRenderedData = false;
+
   async function fetchData() {
     try {
       var path = selectedDeviceId ? '/status/' + encodeURIComponent(selectedDeviceId) : '/';
       var data = await _homey.api('GET', path, {});
       if (data && data.error === 'not_configured') {
-        document.getElementById('loading').classList.add('hidden');
-        document.getElementById('content').classList.add('hidden');
-        document.getElementById('notConfigured').classList.remove('hidden');
+        // Only show the placeholder if we have never had data. Once real data
+        // has been rendered, a transient not-configured response (app restart,
+        // driver not ready yet) should leave the last known values on screen
+        // rather than blanking the widget.
+        if (!hasRenderedData) {
+          document.getElementById('loading').classList.add('hidden');
+          document.getElementById('content').classList.add('hidden');
+          document.getElementById('notConfigured').classList.remove('hidden');
+        }
         return null;
       }
-      if (data) update(data);
+      if (data) {
+        update(data);
+        hasRenderedData = true;
+      }
       return data;
     } catch(error) {
       console.error('Failed to fetch data:', error);
-      document.getElementById('loading').textContent = 'Error: ' + (error.message || String(error));
+      // Don't wipe good data on a transient failure - only surface the error
+      // while the widget is still on its initial loading state.
+      if (!hasRenderedData) {
+        document.getElementById('loading').textContent = 'Error: ' + (error.message || String(error));
+      }
       return null;
     }
   }
 
   async function startWidget() {
-    var data = await fetchData();
-    var interval = (data && data.pollingInterval) || 180000;
-    setInterval(fetchData, interval);
+    await fetchData();
+    setInterval(fetchData, REFRESH_INTERVAL);
   }
 
   async function onHomeyReady(Homey) {


### PR DESCRIPTION
Fixes #53.

## Summary

Three defects in `widgets/car-status/public/index.html`. The first fully explains "the widget shows the placeholder and never recovers".

### 1. The not-configured panel was never hidden again — permanent stuck state (primary cause)

`update()` restored `#content` and hid `#loading`, but never re-hid `#notConfigured`:

```js
function update(data) {
  document.getElementById('loading').classList.add('hidden');
  document.getElementById('content').classList.remove('hidden');
  // #notConfigured left visible
```

`#notConfigured` is styled `height: 100%` inside a fixed 160px widget, so once shown it covers the entire visible area. A later successful poll un-hid `#content` *underneath* it — the widget looked permanently frozen on "Edit the widget and select a car to display" while fresh data was arriving every cycle.

Easy to hit transiently: the no-device endpoint returns `not_configured` unconditionally (`getStatus` → `getDeviceStatus(null)`), and `app._getDevices()` swallows errors and returns `[]` when the driver isn't ready yet at dashboard load. One such response latched the widget until the dashboard was manually reloaded.

### 2. Refresh rate was tied to the Mercedes API polling interval

```js
var interval = (data && data.pollingInterval) || 180000;
```

`pollingInterval` derives from the device's `polling_interval` setting, which exists to rate-limit **calls to the Mercedes backend** (range 60–3600s). The widget endpoint never touches that API — `getDeviceStatus()` only does local `getCapabilityValue()` reads. So a user who raised polling to 3600s to reduce API load got a dashboard refreshing **once an hour**, despite the app receiving real-time WebSocket pushes.

Now a fixed 15s interval, with a comment explaining why it is deliberately decoupled.

### 3. Transient failures could blank a working widget

A fetch error or a `not_configured` response would tear down the display even if good data was already on screen. Both paths now only take over while nothing has been rendered yet (`hasRenderedData`); afterwards the last known values stay visible and the error goes to the console.

## Test plan
- [x] `npx homey app validate --level publish` — passes.
- [x] `npm test` — 23 tests passing (unchanged; this is front-end widget code with no unit-test harness).
- [x] Extracted the inline `<script>` and syntax-checked it with `node -c`.
- [x] Verified `#notConfigured` is now hidden in `update()` and that the widget no longer references `pollingInterval`.

Note: `pollingInterval` is still returned by `app.getDeviceStatus()` — left in place since it's harmless and removing it would be an unrelated API change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDmJveEAQ35eUsSd5HhxhQ)_