### PR TITLE
Normalize door status values (bool/int/string variants)

### DIFF
--- a/drivers/mercedes-vehicle/device.js
+++ b/drivers/mercedes-vehicle/device.js
@@ -1222,6 +1222,12 @@ class MercedesVehicleDevice extends Homey.Device {
         { keys: ['enginehoodstatus', 'engineHoodStatus', 'hoodStatus'], cap: 'door_hood', name: 'hood' }
       ];
 
+      // Mercedes reports door state as bool, "true"/"false", or a numeric
+      // enum (0/2 = closed, 1 = open - matches mbapi2020's handling), not
+      // just plain booleans, so normalize every variant here.
+      const doorClosedValues = new Set([false, 0, 2, 'false', '0', '2', 'inactive', 'closed']);
+      const doorOpenValues = new Set([true, 1, 'true', '1', 'active', 'open']);
+
       for (const door of doorMappings) {
         // Find the first matching key
         const matchingKey = door.keys.find(k => data[k] !== undefined);
@@ -1232,8 +1238,18 @@ class MercedesVehicleDevice extends Homey.Device {
               continue;
             }
             const doorData = data[matchingKey];
-            const newStatus = doorData === true ? 'Open' : doorData === false ? 'Closed' : String(doorData);
+            const normalized = typeof doorData === 'string' ? doorData.toLowerCase() : doorData;
+            let newStatus;
+            if (doorOpenValues.has(normalized)) {
+              newStatus = 'Open';
+            } else if (doorClosedValues.has(normalized)) {
+              newStatus = 'Closed';
+            } else {
+              this.log(`[UPDATE] WARNING: Unrecognized ${door.cap} raw value: ${JSON.stringify(doorData)} (type: ${typeof doorData})`);
+              newStatus = String(doorData);
+            }
             const oldStatus = this.getCapabilityValue(door.cap);
+            this.log(`[UPDATE] Setting ${door.cap} to: ${newStatus} (raw: ${JSON.stringify(doorData)}, old: ${oldStatus})`);
             await this.setCapabilityValue(door.cap, newStatus);
 
             // Trigger flow cards on status change


### PR DESCRIPTION
## Summary

Supersedes #59, which could not be merged (`mergeable_state: dirty` — its `lib/log-redactor.js` predates and conflicts with the working redactor from #47–#52). This PR pulls out only the one genuinely useful, unrelated change from that branch: door status value normalization. Nothing else from #59 (its own log-redactor, `lib/redact.js`, `scripts/`, or its 1.1.33 version bump) is included — this branch is based on current `main` and leaves version/changelog untouched at 1.1.37.

Door status was only ever handled as a plain boolean:

```js
doorData === true ? 'Open' : doorData === false ? 'Closed' : String(doorData)
```

Mercedes has been observed (per mbapi2020) to report door state as a numeric enum (`0`/`2` = closed, `1` = open) or as the strings `"true"`/`"false"`, not just actual booleans. Any of those fell through to `String(doorData)`, producing a literal `"0"`, `"2"` or `"true"` capability value instead of `Open`/`Closed`.

Now normalizes bool, numeric-enum, and case-insensitive string forms to `Open`/`Closed`, and logs a `WARNING` with the raw value for anything genuinely unrecognized, so a future new encoding shows up in the logs instead of silently displaying a raw code.

## Test plan
- [x] `npm test` — 23 tests passing (unchanged; this logic is embedded in `updateCapabilities()`, which — like the rest of that function — isn't unit-testable without mocking the Homey SDK, consistent with how the neighboring window/door mapping loops are already handled in this codebase).
- [x] `npx homey app validate --level publish` — passes.
- [x] `node -c` on the touched file.
- [x] Diffed every `setCapabilityValue`/`getDeviceTriggerCard`/`hasCapability` call in `device.js` before vs. after — identical, so no logic outside the door-status conversion changed.
- [x] Confirmed `app.json`/`.homeycompose/app.json` version is untouched (1.1.37).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDmJveEAQ35eUsSd5HhxhQ)_