### PR TITLE
Fix app crash when tearing down a still-connecting WebSocket (issue #57)

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -688,19 +688,36 @@ class MercedesWebSocket {
     }
 
     if (this.ws) {
+      const socket = this.ws;
+      this.ws = null;
+
       try {
         // Drop listeners first: this socket is being abandoned, and its
         // late 'close' event must not drive reconnect scheduling (the
         // caller owns that decision).
-        this.ws.removeAllListeners();
-        if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
-          this.ws.close(1000, 'Client reconnect');
+        socket.removeAllListeners();
+
+        // ...but leave exactly one 'error' listener behind. Closing a socket
+        // that is still CONNECTING makes `ws` abort the handshake, and that
+        // abort reports itself by emitting 'error' ("WebSocket was closed
+        // before the connection was established") on a *later tick*. An
+        // EventEmitter with no 'error' listener throws instead of emitting,
+        // so that arrives as an uncaught exception - after this try/catch
+        // has already returned, and outside any caller's try/catch too,
+        // which is how a routine teardown crashed the app. A socket that
+        // fails during its closing handshake does the same. This socket is
+        // being discarded either way, so the error carries no information
+        // the caller can act on: log it and let it go.
+        socket.on('error', (error) => {
+          this.homey.app.log(`[WS] Ignoring error from abandoned socket: ${error.message}`);
+        });
+
+        if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+          socket.close(1000, 'Client reconnect');
         }
       } catch (error) {
         this.homey.app.error('[WS] Error closing WebSocket during teardown:', error.message);
       }
-
-      this.ws = null;
     }
 
     this.connectionState = 'disconnected';

--- a/test/websocket-reconnect.test.js
+++ b/test/websocket-reconnect.test.js
@@ -2,6 +2,7 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
 const WebSocket = require('ws');
 const MercedesWebSocket = require('../lib/websocket');
 
@@ -28,10 +29,50 @@ function fakeSocket(readyState = WebSocket.OPEN) {
     readyState,
     closed: false,
     listenersRemoved: false,
+    handlers: {},
+    on(event, fn) {
+      (this.handlers[event] = this.handlers[event] || []).push(fn);
+      return this;
+    },
     close() { this.closed = true; },
-    removeAllListeners() { this.listenersRemoved = true; },
+    removeAllListeners() { this.handlers = {}; this.listenersRemoved = true; },
     ping() {},
   };
+}
+
+/**
+ * Socket that reproduces what `ws` does when a still-CONNECTING socket is
+ * closed: it aborts the handshake and reports that by emitting 'error' on a
+ * later tick (`process.nextTick(emitErrorAndClose, ...)` in ws/lib/websocket.js).
+ *
+ * The emit is a real EventEmitter emit, which is the point - an 'error' with
+ * no listener throws instead of being delivered. In production that throw
+ * lands on a bare tick, so no try/catch anywhere up the call stack can hold
+ * it and the app goes down. Here the throw is captured in `unhandledError`
+ * so the regression fails as an assertion rather than by killing the run.
+ */
+class AbortingHandshakeSocket extends EventEmitter {
+  constructor() {
+    super();
+    this.readyState = WebSocket.CONNECTING;
+    this.closed = false;
+    this.unhandledError = null;
+  }
+
+  ping() {}
+
+  close() {
+    this.closed = true;
+    this.readyState = WebSocket.CLOSED;
+    process.nextTick(() => {
+      try {
+        this.emit('error', new Error('WebSocket was closed before the connection was established'));
+        this.emit('close', 1006, Buffer.alloc(0));
+      } catch (error) {
+        this.unhandledError = error;
+      }
+    });
+  }
 }
 
 test('ping interval stays below the connection watchdog timeout', () => {
@@ -82,6 +123,37 @@ test('_teardownSocket releases the socket without blocking reconnects', () => {
   assert.equal(sock.listenersRemoved, true, 'abandoned socket must not keep driving events');
   assert.equal(ws.isConnecting, false);
   assert.equal(ws.connectionState, 'disconnected');
+});
+
+test('_teardownSocket does not crash on a socket that never finished connecting', async () => {
+  // Reported on issue #57: a routine health-check reconnect took the app
+  // down with "WebSocket was closed before the connection was established",
+  // thrown from ws's close() via _teardownSocket(). Tearing down a socket
+  // mid-handshake is completely normal - the health check does it every time
+  // it replaces a connection that is stuck connecting - so it must not be
+  // fatal. The cause was removeAllListeners() stripping the 'error' listener
+  // moments before close() caused an 'error' to be emitted.
+  const ws = makeWs();
+  const sock = new AbortingHandshakeSocket();
+  ws.ws = sock;
+
+  ws._teardownSocket();
+
+  assert.ok(
+    sock.listenerCount('error') > 0,
+    'an abandoned socket must keep an error listener, or its abort throws',
+  );
+
+  // Let the handshake abort land.
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(
+    sock.unhandledError,
+    null,
+    `abandoned socket must not raise an unhandled error (${sock.unhandledError && sock.unhandledError.message})`,
+  );
+  assert.equal(ws.ws, null, 'socket reference must still be released');
+  assert.equal(sock.closed, true, 'connecting socket must still be closed');
 });
 
 test('_teardownSocket rejects pending commands so callers do not hang', async () => {


### PR DESCRIPTION
Fixes the crash reported on #57 after v1.1.38:

```
Error: WebSocket was closed before the connection was established
    at WebSocket.close (/app/node_modules/ws/lib/websocket.js:299:7)
    at MercedesWebSocket._teardownSocket (/app/lib/websocket.js:697:19)
    at MercedesWebSocket.disconnect (/app/lib/websocket.js:994:10)
    at MercedesAPI.connectWebSocket (/app/lib/api.js:632:24)
    at async Timeout._onTimeout (/app/drivers/mercedes-vehicle/device.js:538:11)
```

## Cause

`_teardownSocket()` called `removeAllListeners()` and then `close()`.

When the socket has not finished its handshake, `ws` answers `close()` by aborting the handshake, and it reports that abort by emitting `'error'` — not synchronously, but via `process.nextTick(emitErrorAndClose, ...)`. The listeners had just been removed, so nothing was there to receive it, and an `EventEmitter` with no `'error'` listener throws rather than emits. Because that throw happens on a bare tick, neither the `try/catch` inside `_teardownSocket()` nor the one wrapping `disconnect()` in `api.connectWebSocket()` could hold it, so it surfaced as an uncaught exception.

The stack in the report is consistent with this: `Error.captureStackTrace(err, abortHandshake)` hides the abort frame, so the error carries the stack of the `close()` call that created it while being thrown a tick later.

Tearing down a half-open socket is routine rather than exceptional — the 5-minute health check does it whenever it replaces a connection that is stuck connecting, which is exactly the path in the trace. So the fault was reachable on an ordinary reconnect.

## Fix

`_teardownSocket()` still removes the abandoned socket's listeners (that part matters — a superseded socket must not drive reconnect scheduling), but leaves exactly one `'error'` listener behind, which logs the event and drops it. The socket is being discarded, so a late error carries nothing a caller could act on. This covers the closing-handshake failure case too, where an already-open socket errors on its way out.

## Tests

One regression test in `test/websocket-reconnect.test.js`, using a socket that reproduces ws's abort semantics — a real `EventEmitter` emitting `'error'` on a later tick, so the no-listener case genuinely throws. It fails against `main` (`an abandoned socket must keep an error listener, or its abort throws`) and passes here. Full suite: 54/54.

No version bump — `.github/workflows/version.yml` is dispatched manually.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCBQUdk9vy5oxfo6SGeCqM)_