### PR TITLE
Add Dutch and German changelog entries for v1.1.39

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -138,6 +138,8 @@
     "de": "Behoben: Fahrzeugbefehle (Verriegeln, Fenster, Ladelimit) schlugen fehl und blieben blockiert, bis Mercedes die Sperre aufhob — die App öffnete für jeden Befehl eine neue Verbindung, statt die bestehende weiterzuverwenden. Ebenfalls behoben: Statusaktualisierungen wurden manchmal doppelt verarbeitet, wodurch Flows doppelt ausgelöst werden konnten, und das maximale Ladelimit blieb leer."
   },
   "1.1.39": {
-    "en": "Fixed the app crashing while re-establishing its connection to the car. Replacing a connection that had not finished opening yet could bring the whole app down, which the automatic connection check could trigger on its own."
+    "en": "Fixed the app crashing while re-establishing its connection to the car. Replacing a connection that had not finished opening yet could bring the whole app down, which the automatic connection check could trigger on its own.",
+    "nl": "Opgelost: de app crashte tijdens het opnieuw opbouwen van de verbinding met de auto. Het vervangen van een verbinding die nog niet volledig tot stand was gekomen kon de hele app laten crashen — iets wat de automatische verbindingscontrole zelf kon veroorzaken.",
+    "de": "Behoben: Die App stürzte beim Wiederherstellen der Verbindung zum Fahrzeug ab. Das Ersetzen einer Verbindung, die noch nicht vollständig aufgebaut war, konnte die gesamte App zum Absturz bringen — was die automatische Verbindungsprüfung von sich aus auslösen konnte."
   }
 }


### PR DESCRIPTION
The version workflow writes `.homeychangelog.json` in English only. This adds the `nl` and `de` entries for v1.1.39, same as was done for v1.1.38, so the store listing reads consistently in the locales the app manifest already supports.

Changelog only — no code changes. Landing this before the publish workflow runs so the published build carries all three locales.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCBQUdk9vy5oxfo6SGeCqM)_