### PR TITLE
Stop commands overlapping, and explain RIS_COULD_NOT_SEND_COMMAND

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -66,12 +66,24 @@ class MercedesWebSocket {
     this.messageHandler = null;
 
     // Command tracking for responses
-    this.pendingCommands = new Map(); // requestId -> { resolve, reject, timeout, settleCompletion }
+    this.pendingCommands = new Map();
 
-    // Backend-side completion of the most recent command, and how long the
-    // next one will wait for it. See _awaitPreviousCommandCompletion().
-    this._commandCompletion = null;
-    this.COMMAND_COMPLETION_WAIT = 60000;
+    // The most recent command Mercedes has not reported as ended.
+    // See _awaitPreviousCommandCompletion().
+    this._commandInFlight = null;
+
+    // A command's caller and the command itself end at different times.
+    //
+    // The caller is a Homey flow card, so it must be released or failed
+    // quickly. Mercedes, meanwhile, can hold the command open long after
+    // that - a command queued behind a wake-up on a sleeping car - and
+    // refuses any other command while it does. Tracking has to outlive the
+    // caller for the app to know that, but not indefinitely: past
+    // COMMAND_TRACKING_TIMEOUT the app stops believing the command is open
+    // rather than blocking every later command on a status that never came.
+    this.COMMAND_CALLER_TIMEOUT = 90000; // 90s - flow card gives up
+    this.COMMAND_TRACKING_TIMEOUT = 300000; // 5 min - app stops tracking
+    this.COMMAND_COMPLETION_WAIT = 60000; // how long a new command waits
 
     // Reconnection management
     this.reconnectAttempts = 0;
@@ -618,6 +630,16 @@ class MercedesWebSocket {
   }
 
   /**
+   * Is a caller still waiting on a command result?
+   */
+  _hasCommandAwaitingCaller() {
+    for (const pending of this.pendingCommands.values()) {
+      if (pending.awaitingCaller) return true;
+    }
+    return false;
+  }
+
+  /**
    * Start connection watchdog timer
    */
   _startConnectionWatchdog() {
@@ -626,7 +648,12 @@ class MercedesWebSocket {
     // While a command is in flight the vehicle can go quiet for a minute or
     // more, so use the longer command timeout - tearing the socket down mid
     // command would abort it for no reason.
-    const timeout = this.pendingCommands.size > 0
+    //
+    // Only a command someone is still waiting on justifies that. A command
+    // the app merely keeps tracking to detect collisions must not buy a dead
+    // socket three extra minutes of tolerance - a silent socket is exactly
+    // the fault behind #56.
+    const timeout = this._hasCommandAwaitingCaller()
       ? this.COMMAND_WATCHDOG_TIMEOUT
       : this.INITIAL_WATCHDOG_TIMEOUT;
 
@@ -703,13 +730,15 @@ class MercedesWebSocket {
 
     // Reject any pending commands so their Promises don't hang
     for (const [, pending] of this.pendingCommands) {
-      clearTimeout(pending.timeout);
+      clearTimeout(pending.callerTimeout);
+      clearTimeout(pending.trackingTimeout);
       // Release anything queued behind this command too: the session that
       // would have reported its completion is going away.
       if (pending.settleCompletion) pending.settleCompletion();
       pending.reject(new Error(reason));
     }
     this.pendingCommands.clear();
+    this._commandInFlight = null;
 
     // Fail an in-flight connect attempt too. Its socket is about to lose
     // its listeners, so nothing would ever settle its promise otherwise -
@@ -856,14 +885,14 @@ class MercedesWebSocket {
         // ends, which is what the next command waits on.
         if (state === 'ACKED_BY_APPTWIN' || state === 'PIN_VALID') {
           this.homey.app.log(`[WS] Command ${requestId} accepted (${state}) - still open at Mercedes`);
+          clearTimeout(pending.callerTimeout);
+          pending.awaitingCaller = false;
           pending.resolve({ success: true, state });
         } else if (state === 'FINISHED') {
-          clearTimeout(pending.timeout);
           this.homey.app.log(`[WS] Command ${requestId} finished`);
           pending.resolve({ success: true, state });
           this._completeCommand(requestId, pending);
         } else if (state === 'FAILED') {
-          clearTimeout(pending.timeout);
           this.homey.app.error(`[WS] Command ${requestId} failed`);
 
           let errorMessage = 'Command failed';
@@ -896,43 +925,64 @@ class MercedesWebSocket {
    * command is waiting behind it.
    */
   _completeCommand(requestId, pending) {
+    clearTimeout(pending.callerTimeout);
+    clearTimeout(pending.trackingTimeout);
+    pending.awaitingCaller = false;
     this.pendingCommands.delete(requestId);
+
+    if (this._commandInFlight && this._commandInFlight.requestId === requestId) {
+      this._commandInFlight = null;
+    }
+
     if (pending.settleCompletion) pending.settleCompletion();
   }
 
   /**
-   * Wait for the previous command to actually end before sending another.
+   * Let the previous command finish before sending another, or say why not.
    *
    * Mercedes will not dispatch a command while it still has one open for the
    * vehicle — it answers RIS_COULD_NOT_SEND_COMMAND ("this command is already
    * running"). The caller's promise resolves at ACKED_BY_APPTWIN so a flow
    * card doesn't sit for a minute waiting on FINISHED, which means a flow's
-   * next action would otherwise go out while the first is still running and
-   * be refused.
+   * next action would otherwise go straight into that window.
    *
-   * Bounded: a command that never reports a terminal state must not block
-   * every later command for good. After the cap we send anyway — the backend
-   * is the authority on whether that's allowed, and its refusal is now
-   * reported in plain language.
+   * A command that has only just been sent is worth waiting for: it normally
+   * completes well inside COMMAND_COMPLETION_WAIT, and the second flow action
+   * then succeeds instead of failing. One that has already been open longer
+   * than that is not — waiting would only postpone a refusal the backend has
+   * effectively already given, so fail now and name how long it has been
+   * open. That is the fact the user needs and the one the raw backend code
+   * never carried.
    */
   async _awaitPreviousCommandCompletion() {
-    const previous = this._commandCompletion;
+    const previous = this._commandInFlight;
     if (!previous) return;
 
-    let timer = null;
-    const completed = await Promise.race([
-      previous.then(() => true),
-      new Promise((resolve) => {
-        timer = setTimeout(() => resolve(false), this.COMMAND_COMPLETION_WAIT);
-      }),
-    ]);
-    if (timer) clearTimeout(timer);
+    const openFor = Date.now() - previous.sentAt;
 
-    if (!completed) {
-      this.homey.app.log(
-        `[WS] Previous command still open after ${this.COMMAND_COMPLETION_WAIT / 1000}s - sending anyway`,
-      );
+    if (openFor < this.COMMAND_COMPLETION_WAIT) {
+      let timer = null;
+      const completed = await Promise.race([
+        previous.completion.then(() => true),
+        new Promise((resolve) => {
+          timer = setTimeout(() => resolve(false), this.COMMAND_COMPLETION_WAIT - openFor);
+        }),
+      ]);
+      if (timer) clearTimeout(timer);
+      if (completed) return;
     }
+
+    // It may have ended while we waited.
+    if (this._commandInFlight !== previous) return;
+
+    const seconds = Math.round((Date.now() - previous.sentAt) / 1000);
+    this.homey.app.error(
+      `[WS] Refusing to send: command ${previous.requestId} has been open at Mercedes for ${seconds}s`,
+    );
+    throw new Error(
+      `Mercedes has had a command open for this vehicle for ${seconds}s and will refuse another one `
+      + 'until it finishes ("this command is already running"). Try again once it has completed.',
+    );
   }
 
   /**
@@ -994,26 +1044,55 @@ class MercedesWebSocket {
     // Send first, then track. Registering the pending command before the
     // send leaked a 90s timer (and an unhandled rejection) whenever the
     // send itself failed.
+    const socket = this.ws;
     await this._sendMessage(message);
+
+    // The socket can be torn down while that send is in flight (shutdown,
+    // recovery). Registering afterwards would arm timers nothing will ever
+    // clear and leave a command marked as open at Mercedes on a session that
+    // no longer exists - which would then fail every later command.
+    if (this.ws !== socket) {
+      throw new Error('WebSocket connection was replaced while the command was being sent');
+    }
+
     this.homey.app.log(`[WS] Command ${requestId} sent, waiting for completion...`);
 
     // Settles when Mercedes reports this command finished or failed - which is
     // later than the caller's promise, and is what the next command waits on.
     let settleCompletion;
-    this._commandCompletion = new Promise((resolve) => { settleCompletion = resolve; });
+    const sentAt = Date.now();
+    const completion = new Promise((resolve) => { settleCompletion = resolve; });
+    this._commandInFlight = { requestId, sentAt, completion };
 
     // Wait for FINISHED or FAILED status
     const commandPromise = new Promise((resolve, reject) => {
-      const timeoutMs = 90000; // 90 seconds (commands can take ~60s)
-      const timeout = setTimeout(() => {
-        this.pendingCommands.delete(requestId);
-        settleCompletion();
-        // A no-op once the command was already accepted: the caller has its
-        // result and only the completion tracking was still outstanding.
-        reject(new Error('Command timed out after 90 seconds'));
-      }, timeoutMs);
+      // The flow card gives up here. Tracking deliberately does not: Mercedes
+      // can still have the command open, and the next command needs to know.
+      const callerTimeout = setTimeout(() => {
+        const pending = this.pendingCommands.get(requestId);
+        if (pending) pending.awaitingCaller = false;
+        this.homey.app.error(`[WS] Command ${requestId} timed out after ${this.COMMAND_CALLER_TIMEOUT / 1000}s - still tracking it`);
+        reject(new Error(`Command timed out after ${this.COMMAND_CALLER_TIMEOUT / 1000} seconds`));
+      }, this.COMMAND_CALLER_TIMEOUT);
 
-      this.pendingCommands.set(requestId, { resolve, reject, timeout, settleCompletion });
+      // Past this the app stops believing the command is open, rather than
+      // blocking every later command on a final status that never came.
+      const trackingTimeout = setTimeout(() => {
+        const pending = this.pendingCommands.get(requestId);
+        if (!pending) return;
+        this.homey.app.log(`[WS] No final status for command ${requestId} after ${this.COMMAND_TRACKING_TIMEOUT / 1000}s - no longer tracking it`);
+        this._completeCommand(requestId, pending);
+      }, this.COMMAND_TRACKING_TIMEOUT);
+
+      this.pendingCommands.set(requestId, {
+        resolve,
+        reject,
+        callerTimeout,
+        trackingTimeout,
+        settleCompletion,
+        sentAt,
+        awaitingCaller: true,
+      });
     });
 
     // Restart the watchdog now that the command is registered: it can take a

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -5,6 +5,26 @@ const https = require('https');
 const crypto = require('crypto');
 
 /**
+ * Backend command-failure codes worth saying in plain language.
+ *
+ * Mercedes reports these on a command status update, usually with an empty
+ * message field, and the raw code is what ends up on a Homey flow card -
+ * where it tells the user nothing about what to do next. Only codes whose
+ * meaning is actually established belong here; anything else keeps falling
+ * through to the code-and-message form, which is still better than a guess.
+ */
+const COMMAND_ERROR_MESSAGES = {
+  // Reported by Mercedes as "this command is already running": the backend
+  // refuses to dispatch while it still has an earlier command open for the
+  // vehicle. A command the app already reported as accepted can stay open for
+  // minutes - e.g. when the car is asleep and the command is queued behind a
+  // wake-up - so this is what a second flow action tends to hit.
+  RIS_COULD_NOT_SEND_COMMAND:
+    'Mercedes is still busy with an earlier command for this vehicle, so it refused this one. '
+    + 'Wait for the previous command to finish and try again.',
+};
+
+/**
  * Mercedes-Benz WebSocket Client
  * Handles real-time push updates from Mercedes API
  * Based on Home Assistant mbapi2020 websocket implementation
@@ -512,7 +532,11 @@ class MercedesWebSocket {
           // Handle command responses
           this._handleCommandStatusUpdates(message.apptwinCommandStatusUpdatesByVin);
 
-          if (message.apptwinCommandStatusUpdatesByVin.sequenceNumber) {
+          // sequenceNumber 0 is a real sequence number - the first update of a
+          // session carries it. A truthiness check dropped that ack, leaving
+          // the backend re-sending an update it considers undelivered. Same
+          // fault as the vepUpdates ack above, same fix.
+          if (message.apptwinCommandStatusUpdatesByVin.sequenceNumber != null) {
             ackMessage = this.protoParser.createAcknowledgeAppTwinCommandStatusUpdateByVin(
               message.apptwinCommandStatusUpdatesByVin.sequenceNumber
             );
@@ -523,7 +547,7 @@ class MercedesWebSocket {
         case 'serviceStatusUpdates':
           {
             const ssu = message.serviceStatusUpdates || message.service_status_updates;
-            if (ssu && ssu.sequenceNumber) {
+            if (ssu && ssu.sequenceNumber != null) {
               ackMessage = this.protoParser.createAcknowledgeServiceStatusUpdate(ssu.sequenceNumber);
             }
           }
@@ -533,7 +557,7 @@ class MercedesWebSocket {
         case 'userDataUpdate':
           {
             const udu = message.userDataUpdate || message.user_data_update;
-            if (udu && udu.sequenceNumber) {
+            if (udu && udu.sequenceNumber != null) {
               ackMessage = this.protoParser.createAcknowledgeUserDataUpdate(udu.sequenceNumber);
             }
           }
@@ -828,11 +852,19 @@ class MercedesWebSocket {
 
           let errorMessage = 'Command failed';
           if (status.errors && status.errors.length > 0) {
+            const parts = [];
             for (const err of status.errors) {
               this.homey.app.error(`[WS] Error: Code=${err.code}, Message=${err.message}`);
-              if (err.message) errorMessage += `: ${err.message}`;
-              if (err.code) errorMessage += ` (${err.code})`;
+
+              // Prefer the explanation over Mercedes' own text: these codes
+              // usually arrive with an empty message, so the flow card ended
+              // up showing nothing but the raw code.
+              const explained = COMMAND_ERROR_MESSAGES[err.code];
+              if (explained) parts.push(`${explained} (${err.code})`);
+              else if (err.message) parts.push(`${err.message} (${err.code})`);
+              else if (err.code) parts.push(err.code);
             }
+            if (parts.length > 0) errorMessage += `: ${parts.join('; ')}`;
           }
 
           pending.reject(new Error(errorMessage));

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -66,7 +66,12 @@ class MercedesWebSocket {
     this.messageHandler = null;
 
     // Command tracking for responses
-    this.pendingCommands = new Map(); // requestId -> { resolve, reject, timeout, commandType }
+    this.pendingCommands = new Map(); // requestId -> { resolve, reject, timeout, settleCompletion }
+
+    // Backend-side completion of the most recent command, and how long the
+    // next one will wait for it. See _awaitPreviousCommandCompletion().
+    this._commandCompletion = null;
+    this.COMMAND_COMPLETION_WAIT = 60000;
 
     // Reconnection management
     this.reconnectAttempts = 0;
@@ -699,6 +704,9 @@ class MercedesWebSocket {
     // Reject any pending commands so their Promises don't hang
     for (const [, pending] of this.pendingCommands) {
       clearTimeout(pending.timeout);
+      // Release anything queued behind this command too: the session that
+      // would have reported its completion is going away.
+      if (pending.settleCompletion) pending.settleCompletion();
       pending.reject(new Error(reason));
     }
     this.pendingCommands.clear();
@@ -841,11 +849,19 @@ class MercedesWebSocket {
 
         // Resolve on acceptance (ACKED/PIN_VALID) or completion (FINISHED).
         // Don't wait for FINISHED — it can take 60s+ and exceeds Homey's flow timeout.
-        if (state === 'ACKED_BY_APPTWIN' || state === 'PIN_VALID' || state === 'FINISHED') {
-          clearTimeout(pending.timeout);
-          this.homey.app.log(`[WS] Command ${requestId} accepted (${state})`);
+        //
+        // Acceptance settles the *caller*, not the command: Mercedes still has
+        // it open, and refuses an overlapping one with
+        // RIS_COULD_NOT_SEND_COMMAND. So keep tracking it until it genuinely
+        // ends, which is what the next command waits on.
+        if (state === 'ACKED_BY_APPTWIN' || state === 'PIN_VALID') {
+          this.homey.app.log(`[WS] Command ${requestId} accepted (${state}) - still open at Mercedes`);
           pending.resolve({ success: true, state });
-          this.pendingCommands.delete(requestId);
+        } else if (state === 'FINISHED') {
+          clearTimeout(pending.timeout);
+          this.homey.app.log(`[WS] Command ${requestId} finished`);
+          pending.resolve({ success: true, state });
+          this._completeCommand(requestId, pending);
         } else if (state === 'FAILED') {
           clearTimeout(pending.timeout);
           this.homey.app.error(`[WS] Command ${requestId} failed`);
@@ -868,10 +884,54 @@ class MercedesWebSocket {
           }
 
           pending.reject(new Error(errorMessage));
-          this.pendingCommands.delete(requestId);
+          this._completeCommand(requestId, pending);
         }
         // For INITIATED, ENQUEUED, PROCESSING, WAITING states, keep waiting (timeout remains active)
       }
+    }
+  }
+
+  /**
+   * Stop tracking a command that has genuinely ended, and release whatever
+   * command is waiting behind it.
+   */
+  _completeCommand(requestId, pending) {
+    this.pendingCommands.delete(requestId);
+    if (pending.settleCompletion) pending.settleCompletion();
+  }
+
+  /**
+   * Wait for the previous command to actually end before sending another.
+   *
+   * Mercedes will not dispatch a command while it still has one open for the
+   * vehicle — it answers RIS_COULD_NOT_SEND_COMMAND ("this command is already
+   * running"). The caller's promise resolves at ACKED_BY_APPTWIN so a flow
+   * card doesn't sit for a minute waiting on FINISHED, which means a flow's
+   * next action would otherwise go out while the first is still running and
+   * be refused.
+   *
+   * Bounded: a command that never reports a terminal state must not block
+   * every later command for good. After the cap we send anyway — the backend
+   * is the authority on whether that's allowed, and its refusal is now
+   * reported in plain language.
+   */
+  async _awaitPreviousCommandCompletion() {
+    const previous = this._commandCompletion;
+    if (!previous) return;
+
+    let timer = null;
+    const completed = await Promise.race([
+      previous.then(() => true),
+      new Promise((resolve) => {
+        timer = setTimeout(() => resolve(false), this.COMMAND_COMPLETION_WAIT);
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+
+    if (!completed) {
+      this.homey.app.log(
+        `[WS] Previous command still open after ${this.COMMAND_COMPLETION_WAIT / 1000}s - sending anyway`,
+      );
     }
   }
 
@@ -914,6 +974,10 @@ class MercedesWebSocket {
    * access.
    */
   async _sendCommandExclusive(message, requestId) {
+    // Mercedes refuses a command while it still has one open for the vehicle,
+    // and acceptance is not completion - see _awaitPreviousCommandCompletion().
+    await this._awaitPreviousCommandCompletion();
+
     if (!this.isHealthy()) {
       await this._connectForCommand();
     } else {
@@ -933,15 +997,23 @@ class MercedesWebSocket {
     await this._sendMessage(message);
     this.homey.app.log(`[WS] Command ${requestId} sent, waiting for completion...`);
 
+    // Settles when Mercedes reports this command finished or failed - which is
+    // later than the caller's promise, and is what the next command waits on.
+    let settleCompletion;
+    this._commandCompletion = new Promise((resolve) => { settleCompletion = resolve; });
+
     // Wait for FINISHED or FAILED status
     const commandPromise = new Promise((resolve, reject) => {
       const timeoutMs = 90000; // 90 seconds (commands can take ~60s)
       const timeout = setTimeout(() => {
         this.pendingCommands.delete(requestId);
+        settleCompletion();
+        // A no-op once the command was already accepted: the caller has its
+        // result and only the completion tracking was still outstanding.
         reject(new Error('Command timed out after 90 seconds'));
       }, timeoutMs);
 
-      this.pendingCommands.set(requestId, { resolve, reject, timeout });
+      this.pendingCommands.set(requestId, { resolve, reject, timeout, settleCompletion });
     });
 
     // Restart the watchdog now that the command is registered: it can take a

--- a/test/websocket-command-session.test.js
+++ b/test/websocket-command-session.test.js
@@ -477,3 +477,73 @@ test('a healthy but idle connection is not mistaken for a zombie', async () => {
     cleanup(ws);
   }
 });
+
+/**
+ * Reported on issue #57: a flow action failed with nothing but
+ * "Command failed (RIS_COULD_NOT_SEND_COMMAND)". Mercedes sends that code
+ * with an empty message field, so the card showed the user a backend symbol
+ * and no indication of what to do about it.
+ */
+test('a known backend failure code is reported in plain language', async () => {
+  const ws = makeWs();
+
+  const rejected = new Promise((resolve, reject) => {
+    ws.pendingCommands.set('req-1', {
+      resolve,
+      reject,
+      timeout: setTimeout(() => {}, 0),
+    });
+  });
+
+  ws._handleCommandStatusUpdates({
+    updatesByVin: {
+      VIN1: {
+        updatesByPid: {
+          pid1: {
+            requestId: 'req-1',
+            state: 6, // FAILED
+            errors: [{ code: 'RIS_COULD_NOT_SEND_COMMAND', message: '' }],
+          },
+        },
+      },
+    },
+  });
+
+  const error = await rejected.then(() => null, (err) => err);
+
+  assert.ok(error, 'the command must reject');
+  assert.match(error.message, /still busy with an earlier command/);
+  // The raw code stays in the message - it is what makes a future report searchable.
+  assert.match(error.message, /RIS_COULD_NOT_SEND_COMMAND/);
+});
+
+test('an unknown backend failure code still reports code and message', async () => {
+  const ws = makeWs();
+
+  const rejected = new Promise((resolve, reject) => {
+    ws.pendingCommands.set('req-2', {
+      resolve,
+      reject,
+      timeout: setTimeout(() => {}, 0),
+    });
+  });
+
+  ws._handleCommandStatusUpdates({
+    updatesByVin: {
+      VIN1: {
+        updatesByPid: {
+          pid1: {
+            requestId: 'req-2',
+            state: 6,
+            errors: [{ code: 'RIS_SOMETHING_NEW', message: 'backend said no' }],
+          },
+        },
+      },
+    },
+  });
+
+  const error = await rejected.then(() => null, (err) => err);
+
+  assert.ok(error);
+  assert.match(error.message, /backend said no \(RIS_SOMETHING_NEW\)/);
+});

--- a/test/websocket-command-session.test.js
+++ b/test/websocket-command-session.test.js
@@ -491,7 +491,7 @@ test('a known backend failure code is reported in plain language', async () => {
     ws.pendingCommands.set('req-1', {
       resolve,
       reject,
-      timeout: setTimeout(() => {}, 0),
+      callerTimeout: setTimeout(() => {}, 0),
     });
   });
 
@@ -524,7 +524,7 @@ test('an unknown backend failure code still reports code and message', async () 
     ws.pendingCommands.set('req-2', {
       resolve,
       reject,
-      timeout: setTimeout(() => {}, 0),
+      callerTimeout: setTimeout(() => {}, 0),
     });
   });
 
@@ -613,7 +613,7 @@ test('a failed command releases the next one immediately', async () => {
   }
 });
 
-test('a command that never reports completion does not block later commands forever', async () => {
+test('a command still open past the wait fails with how long it has been open', async () => {
   const ws = makeWs();
   const sockets = scriptSockets(ws);
   ws.COMMAND_COMPLETION_WAIT = 60;
@@ -621,9 +621,7 @@ test('a command that never reports completion does not block later commands fore
   await ws.connect(() => {});
 
   const first = ws.sendCommand(Buffer.from('first'), 'req-1');
-  const second = ws.sendCommand(Buffer.from('second'), 'req-2');
   first.catch(() => {});
-  second.catch(() => {});
 
   await waitFor(() => ws.pendingCommands.has('req-1'), 'the first command is in flight');
 
@@ -631,9 +629,42 @@ test('a command that never reports completion does not block later commands fore
     commandStatus(ws, 'req-1', 7); // accepted, then silence
     await first;
 
-    // The backend is the authority on whether an overlap is allowed; a
-    // command it never reports on must not wedge every later command.
-    await waitFor(() => sockets[0].sent.length === 2, 'the wait is capped', 3000);
+    // Waiting longer would only postpone the refusal Mercedes has already
+    // effectively given, and the raw RIS_COULD_NOT_SEND_COMMAND told the user
+    // nothing. Name the fact that matters instead: how long it has been open.
+    await assert.rejects(
+      ws.sendCommand(Buffer.from('second'), 'req-2'),
+      /has had a command open for this vehicle for \d+s/,
+    );
+    assert.deepEqual(sockets[0].sent, [Buffer.from('first')], 'the doomed command is not sent');
+  } finally {
+    cleanup(ws);
+  }
+});
+
+test('tracking a command past its caller does not relax the liveness watchdog', async () => {
+  const ws = makeWs();
+  scriptSockets(ws);
+
+  await ws.connect(() => {});
+
+  const first = ws.sendCommand(Buffer.from('first'), 'req-1');
+  first.catch(() => {});
+
+  await waitFor(() => ws.pendingCommands.has('req-1'), 'the first command is in flight');
+
+  try {
+    assert.equal(ws._hasCommandAwaitingCaller(), true, 'a flow is waiting on this command');
+
+    commandStatus(ws, 'req-1', 7); // accepted: the caller is done, tracking is not
+    await first;
+
+    // The command is still tracked so the next one can't collide with it, but
+    // nobody is waiting on it any more. Letting that keep the watchdog at the
+    // relaxed command timeout would buy a dead socket three extra minutes -
+    // the silent-socket fault behind #56.
+    assert.equal(ws.pendingCommands.has('req-1'), true, 'still tracked');
+    assert.equal(ws._hasCommandAwaitingCaller(), false, 'but nobody is waiting on it');
   } finally {
     cleanup(ws);
   }

--- a/test/websocket-command-session.test.js
+++ b/test/websocket-command-session.test.js
@@ -547,3 +547,94 @@ test('an unknown backend failure code still reports code and message', async () 
   assert.ok(error);
   assert.match(error.message, /backend said no \(RIS_SOMETHING_NEW\)/);
 });
+
+/** Feed a command status update in, the way the backend would. */
+function commandStatus(ws, requestId, state, errors) {
+  ws._handleCommandStatusUpdates({
+    updatesByVin: {
+      VIN1: { updatesByPid: { pid1: { requestId, state, errors } } },
+    },
+  });
+}
+
+test('a second command waits for the first to finish, not just to be accepted', async () => {
+  const ws = makeWs();
+  const sockets = scriptSockets(ws);
+
+  await ws.connect(() => {});
+
+  const first = ws.sendCommand(Buffer.from('first'), 'req-1');
+  const second = ws.sendCommand(Buffer.from('second'), 'req-2');
+  first.catch(() => {});
+  second.catch(() => {});
+
+  await waitFor(() => ws.pendingCommands.has('req-1'), 'the first command is in flight');
+
+  try {
+    // Acceptance settles the caller, so the flow card returns promptly...
+    commandStatus(ws, 'req-1', 7); // ACKED_BY_APPTWIN
+    assert.deepEqual(await first, { success: true, state: 'ACKED_BY_APPTWIN' });
+
+    // ...but Mercedes still has the command open, and refuses an overlapping
+    // one with RIS_COULD_NOT_SEND_COMMAND. Reported on issue #57 as "cannot
+    // run two actions in a row".
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.deepEqual(sockets[0].sent, [Buffer.from('first')], 'the second command must wait');
+
+    commandStatus(ws, 'req-1', 5); // FINISHED
+    await waitFor(() => sockets[0].sent.length === 2, 'the second command is released');
+    assert.deepEqual(sockets[0].sent[1], Buffer.from('second'));
+  } finally {
+    cleanup(ws);
+  }
+});
+
+test('a failed command releases the next one immediately', async () => {
+  const ws = makeWs();
+  const sockets = scriptSockets(ws);
+
+  await ws.connect(() => {});
+
+  const first = ws.sendCommand(Buffer.from('first'), 'req-1');
+  const second = ws.sendCommand(Buffer.from('second'), 'req-2');
+  first.catch(() => {});
+  second.catch(() => {});
+
+  await waitFor(() => ws.pendingCommands.has('req-1'), 'the first command is in flight');
+
+  try {
+    commandStatus(ws, 'req-1', 6, [{ code: 'RIS_SOMETHING', message: 'nope' }]);
+    await assert.rejects(first, /nope/);
+
+    // Nothing is left running at Mercedes, so there is nothing to wait for.
+    await waitFor(() => sockets[0].sent.length === 2, 'the second command is released');
+  } finally {
+    cleanup(ws);
+  }
+});
+
+test('a command that never reports completion does not block later commands forever', async () => {
+  const ws = makeWs();
+  const sockets = scriptSockets(ws);
+  ws.COMMAND_COMPLETION_WAIT = 60;
+
+  await ws.connect(() => {});
+
+  const first = ws.sendCommand(Buffer.from('first'), 'req-1');
+  const second = ws.sendCommand(Buffer.from('second'), 'req-2');
+  first.catch(() => {});
+  second.catch(() => {});
+
+  await waitFor(() => ws.pendingCommands.has('req-1'), 'the first command is in flight');
+
+  try {
+    commandStatus(ws, 'req-1', 7); // accepted, then silence
+    await first;
+
+    // The backend is the authority on whether an overlap is allowed; a
+    // command it never reports on must not wedge every later command.
+    await waitFor(() => sockets[0].sent.length === 2, 'the wait is capped', 3000);
+  } finally {
+    cleanup(ws);
+  }
+});

--- a/test/websocket-reconnect.test.js
+++ b/test/websocket-reconnect.test.js
@@ -164,7 +164,8 @@ test('_teardownSocket rejects pending commands so callers do not hang', async ()
     ws.pendingCommands.set('req-1', {
       resolve,
       reject,
-      timeout: setTimeout(() => {}, 60000),
+      callerTimeout: setTimeout(() => {}, 60000),
+      trackingTimeout: setTimeout(() => {}, 60000),
       commandType: 'doorsLock',
     });
   });

--- a/test/websocket-vep-ack.test.js
+++ b/test/websocket-vep-ack.test.js
@@ -84,3 +84,62 @@ test('a handler that throws still leaves the update acknowledged', async () => {
   // Otherwise one failing capability write earns an endless re-send loop.
   assert.deepEqual(order, [['ack', 7]]);
 });
+
+/**
+ * The same "0 is a real sequence number" fault existed on the other three ack
+ * paths. It matters most on the command channel: a command status update the
+ * backend considers undelivered is one it keeps re-sending.
+ */
+function instrumentAck(ws, message, ackFactoryName) {
+  const acked = [];
+
+  ws.protoParser = {
+    parsePushMessage: () => message,
+    [ackFactoryName]: (seq) => ({ ack: seq }),
+  };
+  ws._sendMessage = async (msg) => { acked.push(msg.ack); };
+
+  return acked;
+}
+
+test('command status update with sequenceNumber 0 is acknowledged', async () => {
+  const ws = makeWs();
+  const acked = instrumentAck(
+    ws,
+    {
+      msg: 'apptwinCommandStatusUpdatesByVin',
+      apptwinCommandStatusUpdatesByVin: { sequenceNumber: 0, updatesByVin: {} },
+    },
+    'createAcknowledgeAppTwinCommandStatusUpdateByVin',
+  );
+
+  await ws._processMessage(Buffer.alloc(0));
+
+  assert.deepEqual(acked, [0]);
+});
+
+test('service status update with sequenceNumber 0 is acknowledged', async () => {
+  const ws = makeWs();
+  const acked = instrumentAck(
+    ws,
+    { msg: 'serviceStatusUpdates', serviceStatusUpdates: { sequenceNumber: 0 } },
+    'createAcknowledgeServiceStatusUpdate',
+  );
+
+  await ws._processMessage(Buffer.alloc(0));
+
+  assert.deepEqual(acked, [0]);
+});
+
+test('user data update with sequenceNumber 0 is acknowledged', async () => {
+  const ws = makeWs();
+  const acked = instrumentAck(
+    ws,
+    { msg: 'userDataUpdate', userDataUpdate: { sequenceNumber: 0 } },
+    'createAcknowledgeUserDataUpdate',
+  );
+
+  await ws._processMessage(Buffer.alloc(0));
+
+  assert.deepEqual(acked, [0]);
+});


### PR DESCRIPTION
Follow-up to the log posted on #57 (`Can not run two actions in a row with a 2 min delay`, failing with `RIS_COULD_NOT_SEND_COMMAND`).

## What the log shows

This one is **not** a connection fault. The socket is healthy throughout — `vepUpdates` keep arriving and being applied 4 and 12 seconds after the failure. The command was sent successfully and Mercedes answered with a command status of FAILED:

```
[WS] Command be36d4b7-… failed
[WS] Error: Code=RIS_COULD_NOT_SEND_COMMAND, Message=
[FLOW] Failed to close windows: Command failed (RIS_COULD_NOT_SEND_COMMAND)
```

`RIS_COULD_NOT_SEND_COMMAND` is the backend refusing to dispatch because it still has an earlier command open for that vehicle — reported elsewhere as *"this command is already running"*. It arrives with an empty message field, which is why the flow card showed the bare code.

The app made it easy to hit. A command resolves its caller at `ACKED_BY_APPTWIN` rather than `FINISHED`, deliberately — `FINISHED` can take 60s+ and would blow Homey's flow timeout. But acceptance is not completion: Mercedes still has the command open, and the flow's next action went straight into that window.

## Changes

**1. A command's caller and the command itself now end at different times.** The caller is a flow card, so 90s is right for it. Mercedes can hold the command far longer — queued behind a wake-up on a sleeping car — and refuses every other command while it does. Tracking used to end with the caller, so by the time a second action arrived two minutes later the app had already forgotten the first. Tracking now continues to 5 minutes; past that the app stops believing the command is open rather than blocking later commands on a final status that never came.

**2. Collisions are named, not waited out.** A command that has only just been sent is worth waiting for — it normally completes inside the 60s window, and the second flow action then succeeds instead of failing. One already open longer than that will not finish sooner for being waited on, so the app fails immediately with *"Mercedes has had a command open for this vehicle for 128s and will refuse another one until it finishes"*. That is the fact the bare backend code never carried.

**3. Known backend codes are translated.** `RIS_COULD_NOT_SEND_COMMAND` arriving from the backend now reads as plain language, with the raw code kept in the text so future reports stay searchable. Only codes whose meaning is established are mapped — anything else keeps the code-and-message form rather than a guess.

**4. Sequence number 0 is acked on the remaining channels.** Command status, service status and user data updates still tested the sequence number for truthiness, so a `sequenceNumber` of 0 — the first update of a session — was never acknowledged, and the backend treats an unacked update as undelivered and re-sends it. Fixed for `vepUpdates` in #58; the same fault was left in the other three. It matters most on the command channel, where the unacked update is a command result.

## Two consequences of longer tracking, handled

- **The liveness watchdog** relaxes from 60s to 180s while a command is in flight. It now keys off a command someone is still *waiting on*, not one the app merely tracks — otherwise five-minute tracking would buy a dead socket three extra minutes of tolerance, which is the silent-socket fault behind #56.
- **A socket torn down mid-send** would leave the command registering afterwards, arming timers nothing clears and marking a command open on a session that no longer exists — which would then fail every later command. Registration now checks the socket is still the one it sent on.

## Tests

9 new tests, full suite 62/62 and the suite exits clean (no leaked timers).

Verified against `main`: the overlap test, the watchdog test, the translated-message test and the three ack tests all fail there. The watchdog test fails on `_hasCommandAwaitingCaller is not a function`. The fail-fast test doesn't fail cleanly against the previous commit — it hangs there for the full 90s caller timeout and then fails on the message, which is itself the behaviour being replaced.